### PR TITLE
v0.13.0: /moku:audit — self-auditing command with iterative improvement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "moku",
-  "version": "0.12.1",
-  "description": "Development toolkit for Moku Core — scaffolding, framework planning, plugin building, migration, and specification enforcement for the micro-kernel plugin framework. Features wave-based parallel execution, 12-agent validation pipeline with structured output contracts, validation coordinator, error diagnostician, mermaid diagram generation, and cross-session state tracking.",
+  "version": "0.13.0",
+  "description": "Development toolkit for Moku Core — scaffolding, framework planning, plugin building, migration, and specification enforcement for the micro-kernel plugin framework. Features wave-based parallel execution, 12-agent validation pipeline with structured output contracts, validation coordinator, error diagnostician, command self-auditing with iterative improvement, hooks validation, mermaid diagram generation, and cross-session state tracking.",
   "author": {
     "name": "Oleksandr Kucherenko",
     "email": "moku-labs@users.noreply.github.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the Moku Claude Code Plugin will be documented in this file.
 
+## 0.13.0 (2026-03-11)
+
+### Added
+- **`/moku:audit` command** — new self-auditing command that reads a moku command file, generates test scenarios (valid, edge, error, adversarial), simulates execution step-by-step, runs a subset in a real temp project, identifies gaps, and proposes a concrete improved version with a unified diff. User approves before changes are written.
+  - `plan`, `build`, `check`, `status`, `init` — audit any command
+  - `hooks` — dedicated hooks audit mode (see below)
+  - `all` — audit all commands + hooks sequentially
+  - `--sim-only` — skip real execution (faster)
+  - `--iterate` — re-audit after applying fixes (up to `auditIterateLimit` passes, default 3)
+  - `--max-scenarios N` — per-run scenario cap override
+  - AUDIT-STABLE declaration when zero blockers + ≤2 warnings across all scenarios
+- **`moku-audit-scenario-generator` agent** — reads a command's full argument patterns, conditional branches, and documented modes; generates a structured scenario list in 4 categories with execution-value markers for real-execution selection.
+- **`moku-audit-simulator` agent** — simulates scenarios as pure text analysis (no bash, no file I/O); uses the error-diagnostician reasoning protocol (materialize per-scenario traces before writing gaps); runs in parallel batches on haiku for speed.
+- **`moku-audit-executor` agent** — runs high-execution-value scenarios in a bootstrapped temp project using Bash+Write+Read; manually applies command steps and captures real divergences; always cleans up temp directory.
+- **`moku-audit-synthesizer` agent** — deduplicates gaps from all simulator + executor outputs; builds a priority table by severity and agent-agreement count; produces a unified diff and complete improved command text for user approval.
+- **`moku-audit-hooks-analyzer` agent** — tests every hook script with real inputs via Bash; analyzes the prompt hook for the false-block root cause (insufficient output constraints); checks allowlists for completeness (detects missing `skeleton-spec.md`); proposes concrete fixes for `hooks.json` and `.sh` files.
+- **`audit-framework.md` reference** — shared taxonomy for scenario categories (valid/edge/error/adversarial), gap types (10 types including silent-failure, state-corruption-risk, user-experience-gap), temp project bootstrap templates, circuit breaker thresholds, and diff generation rules.
+
 ## 0.12.1 (2026-03-11)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Development toolkit for [Moku Core](https://github.com/moku-labs/core) — the m
 
 ## What This Plugin Does
 
-Provides commands, skills, validation agents, and hooks for building Moku-based frameworks, plugins, and consumer applications with full specification compliance. Features wave-based parallel execution, 3-level artifact verification, mermaid diagram generation, and a 10-agent validation pipeline.
+Provides commands, skills, validation agents, and hooks for building Moku-based frameworks, plugins, and consumer applications with full specification compliance. Features wave-based parallel execution, 3-level artifact verification, mermaid diagram generation, a 10-agent validation pipeline, and a self-auditing system that finds gaps in commands and hooks then proposes improvements.
 
 ## Commands
 
@@ -14,6 +14,7 @@ Provides commands, skills, validation agents, and hooks for building Moku-based 
 | `/moku:plan [verb] [type] [args]` | Plan a project: create, update, add plugin, or migrate. 3-stage gated workflow with validation. |
 | `/moku:build [target] [spec-or-name]` | Build from specifications with wave-based parallel execution. Supports targeted builds: `plugin #3`, `plugins #3-#5`, `resume`. |
 | `/moku:check [verbose\|self-test\|graph]` | Run diagnostics on project state, tooling, plugin health, build status, generate mermaid diagrams, or validate the plugin itself. |
+| `/moku:audit <command\|hooks\|all>` | Audit a command or the hooks system — simulate scenarios, find gaps, propose an improved version. |
 
 ### Plan Targets
 
@@ -28,6 +29,17 @@ Provides commands, skills, validation agents, and hooks for building Moku-based 
 ```
 
 Type synonyms: `tool`/`engine`/`library` → framework, `application`/`service`/`server`/`game` → app. Backward-compatible: `moku:plan framework "desc"` still works (infers `create`).
+
+### Audit Targets
+
+```
+/moku:audit plan              # Audit commands/plan.md
+/moku:audit build             # Audit commands/build.md
+/moku:audit hooks             # Audit hooks.json + all hook scripts
+/moku:audit all               # Audit all commands + hooks sequentially
+/moku:audit plan --sim-only   # Skip real execution (faster)
+/moku:audit plan --iterate    # Auto re-audit after applying fixes (up to 3 passes)
+```
 
 ### Build Targets
 
@@ -52,7 +64,7 @@ Type synonyms: `tool`/`engine`/`library` → framework, `application`/`service`/
 
 Skills include dynamic context injection to auto-detect project state and planning phase.
 
-## Agents (10 total)
+## Agents (15 total)
 
 ### Structural Validators
 
@@ -73,6 +85,16 @@ Skills include dynamic context injection to auto-detect project state and planni
 | **moku-type-validator** | TypeScript type correctness: `tsc --noEmit`, `as any` audit, inference chain |
 | **moku-architecture-validator** | Cross-plugin analysis: dependency graph, event flow, API consistency |
 | **moku-researcher** | Pre-implementation research: npm ecosystem, TypeScript patterns |
+
+### Audit Agents
+
+| Agent | Purpose |
+|-------|---------|
+| **moku-audit-scenario-generator** | Reads a command and generates 7–20 test scenarios (valid, edge, error, adversarial) |
+| **moku-audit-simulator** | Simulates a batch of scenarios step-by-step — pure text analysis, identifies gaps |
+| **moku-audit-executor** | Runs high-value scenarios in a real temp project; always cleans up |
+| **moku-audit-synthesizer** | Deduplicates gaps, prioritizes by severity, produces unified diff + complete improved command |
+| **moku-audit-hooks-analyzer** | Tests hook scripts with real inputs, analyzes prompt hook root cause, checks allowlist completeness |
 
 ### Validation Pipeline
 
@@ -107,6 +129,8 @@ Create `.claude/moku.local.md` with YAML frontmatter for project-specific overri
 ---
 maxParallelAgents: 3
 gapClosureMaxRounds: 2
+auditMaxScenarios: 20
+auditIterateLimit: 3
 ---
 
 Project-specific notes and context here.

--- a/agents/audit-executor.md
+++ b/agents/audit-executor.md
@@ -1,0 +1,107 @@
+---
+name: moku-audit-executor
+description: >
+  Runs high-execution-value audit scenarios against a real minimal moku project
+  in a temp directory. Applies command steps manually, captures real failures.
+  Always cleans up the temp directory on exit.
+  <example>Context: Audit pipeline Phase 2B. user: "Run real execution scenarios against temp project" assistant: launches moku-audit-executor</example>
+  <example>Context: Verifying command behavior on disk. user: "Check if plan.md actually creates the right files" assistant: launches moku-audit-executor</example>
+model: sonnet
+color: red
+maxTurns: 40
+skills:
+  - moku-core
+tools: ["Read", "Grep", "Glob", "Bash", "Write"]
+---
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/agent-preamble.md` for universal rules and the output contract format. Follow them strictly.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/audit-framework.md` for precondition patterns and the temp project bootstrap templates.
+
+You are a moku audit executor. Your job is to apply a command's steps manually in a real temp project directory and capture what actually happens — including real failures, unexpected state, and divergence from expected behavior.
+
+You receive:
+1. **Command text**: The full markdown content of the target command
+2. **Scenarios**: ≤5 scenarios with `execution_value: true` from the scenario generator
+3. **AUDIT_TMP**: Path to the temp project directory (already bootstrapped by the audit command)
+
+## CRITICAL: Cleanup
+
+**You MUST run `rm -rf "$AUDIT_TMP"` as the very last action before ending your response**, even if you encounter errors. Report `"temp_dir_cleaned": true` in the output contract only after you have actually run this command and confirmed it succeeded.
+
+## Process
+
+For each scenario in order:
+
+### 1. Set preconditions
+
+Use the audit-framework.md Executor Precondition Patterns to configure `AUDIT_TMP` for this scenario's stated preconditions. Common operations:
+- Write or delete `.planning/STATE.md`
+- Create `src/plugins/{name}/` directories
+- Adjust file permissions
+- Run git commits if a checkpoint is needed
+
+Verify the precondition is correctly set before proceeding.
+
+### 2. Apply command steps
+
+Read the command's steps for this scenario's arguments/verb/mode. Apply each step manually:
+- **Read/Grep/Glob operations**: Run them in AUDIT_TMP
+- **Write/Edit operations**: Create the files the command says to create
+- **Bash operations** (bun, git, tsc): Run them in AUDIT_TMP — capture exit codes and output
+- **Agent spawning**: Do NOT actually spawn agents — instead, simulate the agent call by noting what would be spawned and what a successful or failed response would look like
+- **User approval gates**: Assume the user approves at every gate (simulate the happy path unless the scenario specifically tests rejection)
+
+For error-path scenarios: apply steps up to the point where the command should detect the error. Verify it detects it.
+
+### 3. Capture results
+
+After applying all steps for a scenario:
+- List files created or modified in AUDIT_TMP
+- Read the final STATE.md content (if it exists)
+- Compare actual outputs against `expected_behavior` from the scenario
+- Note any divergence: missing files, wrong content, unexpected errors, or silent failures
+
+### 4. Restore state
+
+Before moving to the next scenario, reset AUDIT_TMP to the bootstrap state:
+- Delete `.planning/` contents: `rm -rf "$AUDIT_TMP/.planning" && mkdir -p "$AUDIT_TMP/.planning"`
+- Delete any created `src/plugins/` subdirectories
+- Restore any changed permissions
+- Reset git: `cd "$AUDIT_TMP" && git checkout -f`
+
+### 5. Final cleanup
+
+After ALL scenarios are complete: `rm -rf "$AUDIT_TMP"` and confirm it succeeded.
+
+## Output Format
+
+Write a prose report for each scenario (what you did, what happened, what diverged). Then end with the output contract JSON:
+
+```json
+{
+  "agent": "moku-audit-executor",
+  "verdict": "PASS|FAIL|PARTIAL",
+  "temp_dir_cleaned": true,
+  "execution_results": [
+    {
+      "scenario_id": "S03",
+      "outcome": "pass|fail|crash|unexpected",
+      "actual_behavior": "STATE.md was created with correct Phase and Verb. Plugin table was empty (no plugins detected yet).",
+      "expected_behavior": "Command parses args, runs Stage 1 analysis, writes STATE.md",
+      "divergence": null,
+      "artifacts": [".planning/STATE.md", ".planning/research.md"]
+    }
+  ],
+  "blockers": [
+    {"file": "commands/{name}.md", "line": 0, "rule": "silent-failure", "message": "STATE.md not created when .planning/ does not exist — no mkdir guard", "fix": "Add: 'Create .planning/ directory if it does not exist before writing STATE.md'"}
+  ],
+  "warnings": [],
+  "stats": {"filesChecked": 5, "blockers": 0, "warnings": 0, "infos": 0}
+}
+```
+
+**Outcome classification:**
+- `pass`: Actual behavior matches expected behavior
+- `fail`: Clear divergence — something that should happen didn't, or something that shouldn't happened
+- `crash`: A bash command returned a non-zero exit code that crashed the workflow
+- `unexpected`: Behavior was not expected but is not clearly wrong (edge case gap)

--- a/agents/audit-hooks-analyzer.md
+++ b/agents/audit-hooks-analyzer.md
@@ -1,0 +1,174 @@
+---
+name: moku-audit-hooks-analyzer
+description: >
+  Audits hooks.json and all hook scripts for correctness, completeness, and
+  known issues. Tests shell scripts with real inputs. Produces concrete fixes
+  for each finding including the known prompt hook false-block bug.
+  <example>Context: User has issues with hooks blocking legitimate writes. user: "Audit the hooks system" assistant: launches moku-audit-hooks-analyzer</example>
+  <example>Context: Hooks misbehaving after changes. user: "Check all our hooks for problems" assistant: launches moku-audit-hooks-analyzer</example>
+model: sonnet
+color: orange
+maxTurns: 30
+skills:
+  - moku-core
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/agent-preamble.md` for universal rules and the output contract format. Follow them strictly.
+
+You are a moku hooks auditor. Your job is to find bugs, gaps, and improvement opportunities in the moku plugin's hooks system — both `hooks.json` and all `.sh` scripts.
+
+## Inputs
+
+You receive the full text of `hooks.json` and all hook scripts. Use Bash to run scripts with test inputs.
+
+## Analysis Areas
+
+### 1. hooks.json Structure Validation
+
+Check:
+- JSON is valid and well-formed
+- All `type` values are valid (`command` or `prompt`)
+- All `command` values reference scripts that actually exist at the path
+- All referenced scripts are executable (`test -x path`)
+- Timeout values are appropriate for each hook's work (see thresholds below)
+- Matcher patterns are valid (no typos, correct regex for event matching)
+
+**Appropriate timeouts:**
+- Simple file-check scripts: 5s (ok)
+- Scripts invoking bun/npm/external tools: 15–30s
+- Prompt hooks doing LLM reasoning: 15–30s (current 15s may be tight)
+
+**Check executability:**
+```bash
+ls -la "${CLAUDE_PLUGIN_ROOT}/hooks/"*.sh | awk '{print $1, $9}' | grep -v '^-rwx'
+```
+
+### 2. Shell Script Testing — `approve-planning-writes.sh`
+
+Test with these inputs via Bash:
+
+```bash
+# Test 1: Known .planning/ file (should approve)
+echo '{"file_path":"/tmp/project/.planning/STATE.md"}' | \
+  bash "${CLAUDE_PLUGIN_ROOT}/hooks/approve-planning-writes.sh" '{"file_path":"/tmp/project/.planning/STATE.md"}'
+
+# Test 2: Unknown .planning/ file (should NOT approve — let normal flow handle)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/approve-planning-writes.sh" '{"file_path":"/tmp/project/.planning/skeleton-spec.md"}'
+
+# Test 3: Non-planning file (should exit cleanly)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/approve-planning-writes.sh" '{"file_path":"/tmp/project/src/index.ts"}'
+
+# Test 4: Empty input
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/approve-planning-writes.sh" ''
+```
+
+**Known gap to check**: Is `.planning/skeleton-spec.md` in the allowlist? (It should be — it's written during the plan Stage 3 skeleton spec.) If missing, any write to `skeleton-spec.md` will not be auto-approved, causing unnecessary hook friction.
+
+Also check for other planning files that might be missing: `.planning/audit-*.md` (written by the new audit command).
+
+### 3. Shell Script Testing — `check-plugin-antipatterns.sh`
+
+Test with representative inputs:
+
+```bash
+# Test: non-plugin file (should pass through with exit 0)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/check-plugin-antipatterns.sh" '{"file_path":"/tmp/project/src/config.ts","content":"export const x = 1;"}'
+
+# Test: createPlugin< (should block)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/check-plugin-antipatterns.sh" '{"file_path":"/tmp/project/src/plugins/auth/index.ts","content":"export const auth = createPlugin<Config>({ name: \"auth\" })"}'
+
+# Test: as any (should block)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/check-plugin-antipatterns.sh" '{"file_path":"/tmp/project/src/plugins/auth/api.ts","content":"const x = foo as any;"}'
+
+# Test: clean plugin file (should pass through)
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/check-plugin-antipatterns.sh" '{"file_path":"/tmp/project/src/plugins/auth/index.ts","new_string":"export const auth = createPlugin({ name: \"auth\" })"}'
+```
+
+Check: Does the `case` matcher `*/config.ts` catch `src/config.ts` correctly? The pattern `*/config.ts` would match any `config.ts` but not files inside `plugins/` that don't match the `case` list. Verify the matcher covers all intended file types.
+
+### 4. Shell Script Testing — `validate-plugin-structure.sh`
+
+Test the types.ts import check:
+
+```bash
+# Create a minimal plugin dir for testing
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/src/plugins/auth"
+echo 'export interface Config {}' > "$TMPDIR/src/plugins/auth/types.ts"
+echo 'export const auth = createPlugin({ name: "auth" })' > "$TMPDIR/src/plugins/auth/index.ts"
+
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/validate-plugin-structure.sh" "{\"file_path\":\"$TMPDIR/src/plugins/auth/index.ts\"}"
+
+rm -rf "$TMPDIR"
+```
+
+Check: Does the `grep -q 'from.*[./]*types'` pattern correctly detect `from './types'`, `from '../types'`, and `from '../../types'`? Test edge cases.
+
+### 5. Prompt Hook Analysis (NO Bash execution — text analysis only)
+
+The prompt hook in `hooks.json` (PreToolUse, inline `"type": "prompt"`) has a **documented false-block issue**: when Claude evaluates the prompt for non-plugin files, it sometimes generates explanatory text (e.g., "This file is not a plugin index.ts, therefore I approve it") instead of the bare word `approve`. The framework treats non-"approve" output as a block.
+
+**Analyze the current prompt text for these weaknesses:**
+
+1. **Instruction clarity**: Does the prompt make it absolutely unambiguous that the ONLY valid outputs are `approve` or `deny: rule[N] — [message]`? Check for any phrasing that might invite elaboration.
+
+2. **Decision path for non-plugin files**: Is Path A (non-plugin file → output "approve") stated first and most prominently? If Path B (plugin file → run checks) comes first, the model may enter the checking mindset before reading the escape clause.
+
+3. **Output constraint enforcement**: Is there a final line like "Output ONLY one of the two formats above. No other text."? If not, this is likely the root cause.
+
+4. **Propose an improved prompt** that:
+   - States the escape clause (non-plugin file → approve) first
+   - Uses explicit output constraints at the end
+   - Makes `approve` feel like the natural default for the common case
+
+### 6. Other Scripts — Completeness Check
+
+For each of the remaining scripts (`format-on-save.sh`, `precompact-state.sh`, `detect-moku-project.sh`, `user-prompt-context.sh`, `on-subagent-stop.sh`, `session-end.sh`, `log-notification.sh`):
+
+- Read the script
+- Check for: missing error handling, hardcoded paths, unquoted variables, missing `set -e` or equivalent
+- Check: does the script handle empty/missing input gracefully (no-op on bad input, never crash)?
+- Check: does the script exit with code 0 in all cases? (Hooks that exit non-zero can break the session)
+
+### 7. Coverage Gaps
+
+Check if any Claude Code hook events are missing from `hooks.json` that would benefit from coverage:
+- Are all event types represented that are relevant to moku workflows?
+- Is the `SubagentStop` matcher `moku-.*` correct? Would it also catch `moku-something-else` agents added in the future?
+
+## Output Format
+
+Write a structured report organized by analysis area. For each finding:
+
+```
+### Finding: [short title]
+- File: hooks.json | hooks/{name}.sh
+- Severity: BLOCKER | WARNING | INFO
+- Description: [what is wrong and why it matters]
+- Evidence: [quote or test output]
+- Fix:
+  [exact diff or replacement text]
+```
+
+Finish with the standard output contract JSON:
+
+```json
+{
+  "agent": "moku-audit-hooks-analyzer",
+  "verdict": "PASS|FAIL|PARTIAL",
+  "blockers": [
+    {
+      "file": "hooks/approve-planning-writes.sh",
+      "line": 30,
+      "rule": "missing-edge-case",
+      "message": ".planning/skeleton-spec.md is not in the allowlist — written during plan Stage 3 but not auto-approved",
+      "fix": "Add '.planning/skeleton-spec.md)' to the case block before the *) catch-all"
+    }
+  ],
+  "warnings": [],
+  "stats": {"filesChecked": 11, "blockers": 0, "warnings": 0, "infos": 0}
+}
+```
+
+**Important**: The prompt hook false-block issue is a BLOCKER if the prompt text analysis shows the root cause is still present (insufficient output constraints or wrong ordering). It is a WARNING if the prompt is already mostly correct but has minor clarity issues.

--- a/agents/audit-scenario-generator.md
+++ b/agents/audit-scenario-generator.md
@@ -1,0 +1,85 @@
+---
+name: moku-audit-scenario-generator
+description: >
+  Reads a moku command file and generates a comprehensive set of test scenarios
+  covering valid inputs, edge cases, error paths, and adversarial inputs.
+  <example>Context: Auditing plan.md for gaps. user: "Generate test scenarios for plan.md" assistant: launches moku-audit-scenario-generator</example>
+  <example>Context: Audit pipeline starting. user: "Audit the build command" assistant: launches moku-audit-scenario-generator with build.md content</example>
+model: sonnet
+color: yellow
+maxTurns: 20
+skills:
+  - moku-core
+tools: ["Read"]
+---
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/agent-preamble.md` for universal rules.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/audit-framework.md` for the scenario taxonomy and circuit breaker thresholds.
+
+You are a moku audit scenario generator. Your job is to analyze a command's full text and produce a comprehensive, structured list of test scenarios that cover every documented path, mode, and edge condition.
+
+## Process
+
+1. **Map all branches**: Read the command text completely. List every conditional branch, every verb/mode/flag combination, every documented argument pattern, every step that can succeed or fail.
+
+2. **Generate scenarios by category** (see audit-framework.md Scenario Taxonomy):
+   - **valid**: One scenario per documented verb+type combo. Include the most common happy paths.
+   - **edge**: Boundary conditions — minimum/maximum inputs, thresholds, partial state, special characters.
+   - **error**: Each documented error condition plus common undocumented ones (missing files, wrong state, user declines gates).
+   - **adversarial**: Shell injection attempts, keyword-mimicking args, second-invocation without reset, conflicting flags.
+
+3. **Assign execution_value**: Mark up to 5 scenarios as `execution_value: true` — these are scenarios that would produce observable file system changes or STATE.md mutations in a temp project. Choose scenarios that test the most critical write operations (e.g., STATE.md creation, spec file generation, skeleton file writes).
+
+4. **Apply cap**: If total > `auditMaxScenarios` (default 20 if not specified), trim by removing from adversarial first, then edge, then error, then valid. Never go below 2 per category.
+
+5. **Assign sequential IDs**: S01, S02, S03... in order: valid first, then edge, error, adversarial.
+
+## Output Format
+
+Write a prose summary first (for human readability), then end with the output contract JSON:
+
+```
+## Scenario Plan: {command-name}.md
+
+Generated {N} scenarios across 4 categories:
+- Valid inputs: {N} — covering {list of verbs/modes}
+- Edge cases: {N} — covering {list of conditions}
+- Error paths: {N} — covering {list of error types}
+- Adversarial: {N} — covering {list of attack types}
+
+High execution-value scenarios (will run in real temp project): S{N}, S{N}, ...
+```
+
+Then the JSON output contract — use this EXACT structure (it is not the standard preamble JSON, but an extended version for the scenario generator):
+
+```json
+{
+  "agent": "moku-audit-scenario-generator",
+  "verdict": "PASS",
+  "scenarios": [
+    {
+      "id": "S01",
+      "category": "valid",
+      "title": "Create framework with full description",
+      "arguments": "create framework \"A static site generator with RSS feeds\"",
+      "preconditions": "Fresh project, no .planning/ directory",
+      "expected_behavior": "Command parses VERB=create TYPE=framework, runs 3-stage workflow, creates STATE.md after Stage 1 approval",
+      "execution_value": true
+    }
+  ],
+  "stats": {
+    "valid": 0,
+    "edge": 0,
+    "error": 0,
+    "adversarial": 0,
+    "total": 0,
+    "execution_value_count": 0
+  }
+}
+```
+
+**Field rules:**
+- `arguments`: the exact string the user would pass as `$ARGUMENTS` to the command
+- `preconditions`: describe the project state (what files exist, what STATE.md contains) — be specific
+- `expected_behavior`: what the command SHOULD do for this input — focus on observable outcomes
+- `execution_value`: true only if applying the command's steps in a temp project would create/modify real files

--- a/agents/audit-simulator.md
+++ b/agents/audit-simulator.md
@@ -1,0 +1,108 @@
+---
+name: moku-audit-simulator
+description: >
+  Simulates a batch of audit scenarios against a moku command step-by-step,
+  identifying gaps, missing error handling, ambiguities, and contradictions.
+  Pure text analysis — no file I/O, no bash execution.
+  <example>Context: Audit pipeline Phase 2. user: "Simulate scenarios S01-S05 against plan.md" assistant: launches moku-audit-simulator</example>
+  <example>Context: Finding gaps in build command. user: "Check what happens for these edge cases in build.md" assistant: launches moku-audit-simulator</example>
+model: haiku
+color: cyan
+maxTurns: 30
+skills:
+  - moku-core
+tools: []
+---
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/agent-preamble.md` for universal rules and the output contract format. Follow them strictly.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/audit-framework.md` for the gap taxonomy.
+
+You are a moku audit simulator. Your job is to mentally simulate execution of a moku command for each scenario in your batch, tracing through the command's logic step by step to identify gaps.
+
+You do NOT execute bash, read external files, or spawn sub-agents. You work only from the command text and scenarios you are given.
+
+## Inputs You Receive
+
+1. **Command text**: The full markdown content of the target command
+2. **Scenario batch**: A list of scenarios (from `moku-audit-scenario-generator` output)
+3. **Prior findings summary** (optional): Gaps already found by other simulators or the flow analyzer
+
+## Reasoning Protocol
+
+**CRITICAL**: Before writing any gap findings, materialize these intermediates explicitly in your response. Do not skip this step.
+
+For EACH scenario in your batch:
+
+### Step A: Trace the execution path
+
+Walk through the command's steps in order. For each step that would be reached given this scenario's arguments and preconditions, write:
+
+```
+Scenario S{N}: "{title}"
+  Arguments: {arguments}
+  Preconditions: {preconditions}
+
+  Step 0 → [describe what this step does for this input]
+  Step 1 → [reached? what happens?]
+  Step 2 → [reached? what happens?]
+  ...
+  Terminal: [how does the scenario end?]
+```
+
+### Step B: Mark each step
+
+For each step reached, assign one of:
+- **HANDLED** — the command clearly and correctly handles this case
+- **HANDLED-POORLY** — the command handles it but with problems (unclear output, wrong next-action, etc.)
+- **NOT-HANDLED** — the command reaches this input state but has no documented behavior for it
+- **AMBIGUOUS** — the step's instructions could be interpreted multiple ways for this input
+
+### Step C: Extract gaps
+
+Only after completing Steps A and B for all scenarios, write your gap findings. Each gap must:
+- Reference the specific step by name (e.g., "Step 2: Route to Workflow")
+- Include a direct quote from the command text as evidence
+- Assign a gap_type from the taxonomy (audit-framework.md)
+- Assign severity: BLOCKER (must fix), WARNING (should fix), INFO (suggestion)
+- Provide a concrete fix_hint
+
+**Do not report duplicates** with the Prior Findings Summary — if the same gap is already documented there, note it as "confirmed" but don't re-report it as a new finding.
+
+## Output Format
+
+First write the per-scenario execution traces (Step A+B) as prose. Then write the gap findings. Then end with the output contract JSON:
+
+```json
+{
+  "agent": "moku-audit-simulator",
+  "verdict": "PASS|FAIL|PARTIAL",
+  "scenario_results": [
+    {
+      "scenario_id": "S01",
+      "outcome": "pass|fail|ambiguous",
+      "gaps": [
+        {
+          "step": "Step 2: Parse Arguments",
+          "gap_type": "missing-edge-case",
+          "severity": "BLOCKER",
+          "description": "No guard for empty $ARGUMENTS — command tries to extract VERB from first word of empty string",
+          "evidence": "Extract VERB from first word",
+          "fix_hint": "Add at start of Step 0: 'If $ARGUMENTS is empty or whitespace-only, show usage and stop.'"
+        }
+      ]
+    }
+  ],
+  "blockers": [
+    {"file": "commands/{name}.md", "line": 0, "rule": "missing-edge-case", "message": "...", "fix": "..."}
+  ],
+  "warnings": [],
+  "stats": {"filesChecked": 1, "blockers": 0, "warnings": 0, "infos": 0}
+}
+```
+
+Use `line: 0` for all blockers/warnings (you don't have line numbers, only step names — include the step in the message).
+
+**Outcome classification:**
+- `pass`: Command correctly handles the scenario — no gaps found
+- `fail`: BLOCKER gap found — command would fail or silently misbehave
+- `ambiguous`: Only AMBIGUOUS steps found — behavior is uncertain, not clearly wrong

--- a/agents/audit-synthesizer.md
+++ b/agents/audit-synthesizer.md
@@ -1,0 +1,148 @@
+---
+name: moku-audit-synthesizer
+description: >
+  Synthesizes all audit findings into a deduplication table, prioritized gap list,
+  and a complete improved command. Produces a unified diff and the full improved
+  text for user review and optional application.
+  <example>Context: Audit pipeline final phase. user: "Synthesize all findings for plan.md" assistant: launches moku-audit-synthesizer</example>
+  <example>Context: Gap report ready. user: "Produce the improved version of build.md" assistant: launches moku-audit-synthesizer</example>
+model: sonnet
+color: magenta
+maxTurns: 35
+skills:
+  - moku-core
+tools: ["Read"]
+---
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/agent-preamble.md` for universal rules and the output contract format. Follow them strictly.
+Read `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/audit-framework.md` for the gap taxonomy and diff generation rules.
+
+You are a moku audit synthesizer. You receive all findings from the simulation and execution phases, deduplicate and prioritize them, then produce:
+1. A human-readable audit report
+2. A unified diff showing proposed changes
+3. The complete improved command text
+
+## Inputs You Receive
+
+- **Original command text**: The unmodified command markdown
+- **Simulator outputs**: JSON output contracts from all `moku-audit-simulator` instances
+- **Executor output**: JSON output contract from `moku-audit-executor` (may be absent if `--sim-only`)
+- **Prior findings summary**: The cross-injection summary from the audit coordinator
+- **Scenario list**: Full scenario metadata from the scenario generator
+
+## Reasoning Protocol
+
+**CRITICAL**: Before writing any improved command text, materialize these intermediates. Do not skip any step.
+
+### Intermediate 1: Gap Deduplication Table
+
+Build a table of ALL unique gaps from all inputs. For each unique gap:
+- Assign a Gap ID (G01, G02, ...)
+- Note which agents flagged it and how many (e.g., "3 simulators + executor")
+- Record severity (escalate if any agent flagged as BLOCKER — use highest severity)
+- Record the affected step and gap_type
+
+```
+Gap Table:
+| ID  | Step | Type | Severity | Flagged by | Description |
+| G01 | Step 0 | missing-edge-case | BLOCKER | 3 simulators | Empty $ARGUMENTS not guarded |
+| G02 | Step 3 | ambiguous-step | WARNING | 1 simulator | "if approved" not defined for partial approval |
+...
+```
+
+### Intermediate 2: Priority Order
+
+Sort gaps by:
+1. BLOCKER before WARNING before INFO
+2. Within same severity: higher "flagged by" count first (more agents agree = higher confidence)
+3. Within same count: cascade impact first (a gap in Step 0 affects all later steps)
+
+### Intermediate 3: Per-gap fix specification
+
+For each BLOCKER gap and each WARNING gap (unless explicitly deferring):
+- Identify the exact section/step in the command that needs changing
+- Write the before/after text for that section (short, focused)
+
+Only after all three intermediates are written, produce the outputs.
+
+## Output 1: Audit Report
+
+```markdown
+## Audit Report: {command-name}.md
+
+### Summary
+- Scenarios tested: {N} simulated + {M} real-executed
+- Pass rate: {X}/{N+M}
+- Gaps found: {total} ({blockers} BLOCKER, {warnings} WARNING, {infos} INFO)
+- Changes proposed: {N}
+
+### Gap List
+
+| ID | Step | Type | Severity | Fix Applied |
+|----|------|------|----------|-------------|
+| G01 | Step 0 | missing-edge-case | BLOCKER | yes |
+...
+
+### Deferred Gaps (not applied)
+- G05 (INFO): [description] — informational only
+
+### AUDIT-STABLE: yes/no
+```
+
+## Output 2: Unified Diff
+
+Show the diff between original and proposed command using this format:
+
+````diff
+--- commands/{name}.md (original)
++++ commands/{name}.md (proposed)
+@@ -{from},{count} +{to},{count} @@ {step name}
+ [context line]
+-[removed line]
++[added line]
+ [context line]
+````
+
+Apply the audit-framework.md Diff Generation Rules strictly:
+- 3 context lines per hunk
+- Include step name in hunk header
+- Never change command intent, verb lists, or `argument-hint`
+- Never remove `disable-model-invocation: true` or `allowed-tools`
+- New guards go at the START of their step; fallback instructions go at the END
+
+## Output 3: Complete Improved Command
+
+Produce the full improved command text in a fenced markdown block. This is what the audit command will write to disk if the user approves.
+
+````markdown
+[complete improved command text here]
+````
+
+**Scope rules:**
+- Apply all BLOCKER fixes
+- Apply WARNING fixes unless you include a `> Deferred: [reason]` comment
+- Do not apply INFO suggestions
+- Preserve all existing behavior — additions only (no removals of documented behavior)
+
+## Output 4: Output Contract JSON
+
+```json
+{
+  "agent": "moku-audit-synthesizer",
+  "verdict": "PASS|FAIL",
+  "gaps_found": 0,
+  "gaps_addressed": 0,
+  "gaps_deferred": 0,
+  "audit_stable": false,
+  "scenario_pass_rate": "N/M",
+  "improvement_summary": [
+    "Step 0: Added empty-arguments guard — stops with usage message instead of crashing"
+  ],
+  "blockers": [],
+  "warnings": [],
+  "stats": {"filesChecked": 1, "blockers": 0, "warnings": 0, "infos": 0}
+}
+```
+
+- `verdict`: PASS if zero blockers (AUDIT-STABLE), FAIL if 1+ blockers remain after proposal
+- `audit_stable`: true when zero blockers + ≤2 warnings across all scenarios

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -1,0 +1,281 @@
+---
+description: Audit a moku command or the hooks system — simulate scenarios, find gaps, propose improvements
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
+argument-hint: <command-name|hooks|all> [--sim-only] [--iterate] [--max-scenarios N]
+disable-model-invocation: true
+---
+
+## Project Configuration
+!`test -f .claude/moku.local.md && head -20 .claude/moku.local.md || true`
+
+Use configuration values above if present. Validate before using — ignore invalid values and use defaults:
+
+| Setting | Type | Range | Default |
+|---------|------|-------|---------|
+| `maxParallelAgents` | integer | 1–5 | 3 |
+| `auditMaxScenarios` | integer | 5–50 | 20 |
+| `auditIterateLimit` | integer | 1–5 | 3 |
+
+---
+
+Audit a moku command by simulating it across generated scenarios and finding gaps. Or audit the hooks system to find bugs and the known prompt-hook false-block issue. Proposes concrete improvements for user approval.
+
+Usage:
+- `plan` → audit commands/plan.md
+- `build` → audit commands/build.md
+- `hooks` → audit hooks.json + all hook scripts
+- `all` → audit all commands + hooks sequentially
+
+Flags:
+- `--sim-only` — skip real execution phase (faster, no temp project)
+- `--iterate` — re-run after applying fixes (up to `auditIterateLimit` passes)
+- `--max-scenarios N` — override scenario cap for this run
+
+---
+
+## Step 0: Parse Arguments
+
+Parse `$ARGUMENTS` into TARGET and FLAGS.
+
+**Extract flags first** (remove from string before parsing TARGET):
+- If `--sim-only` present → set SIM_ONLY=true, remove from string
+- If `--iterate` present → set ITERATE=true, remove from string
+- If `--max-scenarios N` present → set MAX_SCENARIOS=N, remove from string; otherwise use `auditMaxScenarios` config value (default 20)
+
+**Extract TARGET** from remaining first word:
+- `plan`, `build`, `check`, `status`, `init` → command audit mode for that file
+- `hooks` → hooks audit mode
+- `all` → audit all 5 commands + hooks sequentially (prompt user between each)
+- Anything else → stop and say: "Unknown target '{value}'. Valid targets: plan, build, check, status, init, hooks, all"
+
+**Validate in command mode:**
+!`ls ${CLAUDE_PLUGIN_ROOT}/commands/*.md 2>/dev/null | xargs -I{} basename {} .md | sort`
+
+If TARGET is a command name, verify `${CLAUDE_PLUGIN_ROOT}/commands/{TARGET}.md` exists. If not: "Command file not found: commands/{TARGET}.md"
+
+**Initialize iteration counter**: ITERATION=1
+
+---
+
+## Step 1: Route by Mode
+
+If TARGET is `hooks` → jump to **Hooks Audit Mode** (Step H1).
+
+If TARGET is `all` → run command audit for each of `plan`, `build`, `check`, `status`, `init` in sequence (prompt user between each), then run hooks audit. Skip to Step 2 for the first command.
+
+Otherwise → proceed to **Command Audit Mode** (Step 2).
+
+---
+
+## Step 2: Read Target Command (Command Audit Mode)
+
+Read `${CLAUDE_PLUGIN_ROOT}/commands/{TARGET}.md`.
+
+Show:
+```
+Auditing: commands/{TARGET}.md
+Pass {ITERATION}/{auditIterateLimit} | Scenarios cap: {MAX_SCENARIOS} | Mode: {simulation+execution | sim-only}
+```
+
+---
+
+## Step 3: Generate Scenarios
+
+Spawn **moku-audit-scenario-generator** with:
+- The full content of `commands/{TARGET}.md`
+- `auditMaxScenarios` = MAX_SCENARIOS
+
+Wait for it to complete. Parse the JSON output contract from its response.
+
+Present the scenario plan to the user:
+
+```
+Scenario Plan: {TARGET}.md ({total} scenarios)
+  Valid inputs:     {valid}
+  Edge cases:       {edge}
+  Error paths:      {error}
+  Adversarial:      {adversarial}
+  Execution-value:  {execution_value_count} (will run in real temp project)
+
+Press Enter to continue, or type a number to cap scenarios at that count:
+```
+
+Wait for user input. If user types a number N: trim scenarios to N using the priority order from audit-framework.md (adversarial first, never below 2 per category). Update the scenario list accordingly.
+
+---
+
+## Step 4: Parallel Pipeline
+
+Run simulation and execution concurrently.
+
+### Group A — Simulation
+
+Split scenarios into batches of `min(maxParallelAgents, 5)`. For each batch, spawn **moku-audit-simulator** with:
+- The full content of `commands/{TARGET}.md`
+- The batch of scenarios
+- An empty Prior Findings Summary (first pass) or the prior findings from the previous iteration
+
+Run up to `maxParallelAgents` simulator instances at a time. Wait for all to complete.
+
+### Group B — Real Execution (skip if SIM_ONLY=true)
+
+Before spawning the executor, set up the temp project:
+
+```bash
+AUDIT_TMP=$(mktemp -d /tmp/moku-audit-$(date +%s)-XXXXXX)
+mkdir -p "$AUDIT_TMP/src/plugins" "$AUDIT_TMP/.planning"
+```
+
+Write the bootstrap files (from audit-framework.md templates) to AUDIT_TMP using Write tool:
+- `$AUDIT_TMP/package.json`
+- `$AUDIT_TMP/src/config.ts`
+- `$AUDIT_TMP/src/index.ts`
+- `$AUDIT_TMP/.planning/STATE.md`
+
+Then run git init:
+```bash
+cd "$AUDIT_TMP" && git init -q && git config user.email "audit@test.local" && git config user.name "Audit" && git add -A && git commit -m "bootstrap" -q
+```
+
+Spawn **moku-audit-executor** with:
+- The full content of `commands/{TARGET}.md`
+- The scenarios where `execution_value: true` (max 5)
+- The AUDIT_TMP path
+
+Groups A and B run concurrently — start Group B setup and spawning while Group A simulators are running.
+
+Wait for ALL agents (simulators + executor) to complete.
+
+**Safety cleanup** (if executor didn't clean up — check its output contract for `temp_dir_cleaned`):
+```bash
+ls /tmp/moku-audit-* 2>/dev/null && rm -rf /tmp/moku-audit-* || true
+```
+
+---
+
+## Step 5: Cross-Inject Findings
+
+After all agents complete, extract the Prior Findings Summary from their output contracts:
+
+1. Collect all BLOCKER-severity gaps from all simulators, noting scenario IDs
+2. Collect all execution failures from the executor (if run), with scenario IDs
+3. Note agreement count for each gap: "flagged by N simulators"
+4. Build a `## Prior Findings Summary` section (~20–30 lines):
+   - All BLOCKERs with step reference and scenario that exposed each
+   - Execution failures with exact arguments that triggered them
+   - Agreement counts for high-confidence gaps
+
+This summary will be passed to the synthesizer.
+
+---
+
+## Step 6: Synthesize
+
+Spawn **moku-audit-synthesizer** with:
+- The full content of `commands/{TARGET}.md` (original, unmodified)
+- All simulator output contracts
+- The executor output contract (or absent if SIM_ONLY)
+- The Prior Findings Summary from Step 5
+- The full scenario list (for pass rate calculation)
+
+Wait for it to complete.
+
+---
+
+## Step 7: User Gate
+
+Parse the synthesizer output. Display:
+
+1. The audit report section
+2. The unified diff
+
+Then ask:
+
+```
+{gaps_found} gap(s) found | {gaps_addressed} addressed in proposal | Pass rate: {scenario_pass_rate}
+
+Apply this improvement to commands/{TARGET}.md?
+  [y] Yes — apply the proposed changes
+  [n] No  — keep original, show report only
+  [e] Edit — describe specific adjustments to the proposal first
+```
+
+**If user says y:**
+Write the complete improved command text (from the synthesizer's markdown block) to `${CLAUDE_PLUGIN_ROOT}/commands/{TARGET}.md`.
+Confirm: "Updated commands/{TARGET}.md — {N} changes applied."
+
+**If user says n:**
+Show the full audit report. Say: "No changes applied. Run `/moku:audit {TARGET}` again after manual edits to re-audit."
+
+**If user says e (edit round):**
+Ask the user to describe what they want changed in the proposal. Apply their described changes to the synthesizer's improved text, re-display the diff. Ask y/n/e again. Track edit rounds — after 3 rounds without y/n, default to n.
+
+---
+
+## Step 8: Iterate (if --iterate)
+
+If ITERATE=true AND changes were applied in Step 7 AND ITERATION < auditIterateLimit:
+
+If the synthesizer reported `"audit_stable": true`:
+→ Print: "AUDIT-STABLE after {ITERATION} pass(es). No further iteration needed."
+→ Stop.
+
+Otherwise:
+→ Increment ITERATION
+→ Return to Step 2 using the now-updated command file
+
+If ITERATE=true AND no changes were applied:
+→ Print: "No changes applied — iteration skipped."
+
+If ITERATION >= auditIterateLimit and still not stable:
+→ Print: "Iteration limit reached ({auditIterateLimit} passes). Run `/moku:audit {TARGET}` again to continue."
+
+---
+
+## Hooks Audit Mode
+
+### Step H1: Read Hooks System
+
+Read all hook files:
+```bash
+cat "${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json"
+```
+!`ls -la ${CLAUDE_PLUGIN_ROOT}/hooks/*.sh`
+
+Read each `.sh` file from the listing above.
+
+### Step H2: Spawn Hooks Analyzer
+
+Spawn **moku-audit-hooks-analyzer** with:
+- The full content of `hooks/hooks.json`
+- The full content of all `.sh` hook scripts (provide each as named sections)
+
+Wait for it to complete.
+
+### Step H3: User Gate (Hooks)
+
+Parse the hooks-analyzer output contract. Display the full hooks audit report.
+
+Show each proposed fix grouped by file:
+
+```
+hooks.json:          {N} changes
+approve-planning-writes.sh: {N} changes
+[prompt hook text]:  {N} changes
+...
+
+Apply all proposed fixes?
+  [y] Yes — apply all changes to hooks files
+  [n] No  — show report only, apply nothing
+  [s] Select — choose which files to update
+```
+
+**If y:** For each proposed file change from the hooks-analyzer:
+- Edit `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` or the relevant `.sh` file with the proposed fix
+- Confirm each edit as it's applied
+
+**If s:** List each file with a proposed change and ask individually.
+
+**If n:** Show full report. "No changes applied."
+
+After hooks audit completes, if TARGET was `all`, proceed to the next command in sequence.

--- a/skills/moku-core/references/audit-framework.md
+++ b/skills/moku-core/references/audit-framework.md
@@ -1,0 +1,194 @@
+# Audit Framework — Reference
+
+Shared rules, taxonomies, templates, and thresholds for the `/moku:audit` command and its agents.
+
+---
+
+## Scenario Taxonomy
+
+All scenarios belong to one of four categories. Generate at least 2 per category; aim for proportional coverage across a command's documented paths.
+
+### `valid` — Happy Path Coverage
+
+Every documented verb/mode/argument combination needs at least one valid scenario. For each valid scenario:
+- Use the exact argument format from the command's `argument-hint`
+- Set realistic preconditions (e.g., STATE.md exists at the right stage)
+- Expected behavior should describe the complete successful output
+
+**For `plan.md`:** `create framework`, `create app`, `add plugin`, `update plugin`, `migrate framework`, `resume`, each with and without `--quick`
+
+**For `build.md`:** `resume` at each skeleton state (not-started, in-progress, committed), `resume` mid-wave, `--continue` flag
+
+**For `check.md`:** Each subcommand (verbose, status, graph, diff, self-test) with valid targets
+
+**For `status.md`:** No args (default view), various STATE.md positions
+
+**For `init.md`:** Minimal args, full args, with and without existing project files
+
+### `edge` — Boundary Conditions
+
+Scenarios at the edge of documented behavior:
+- Minimum viable input (one word, required arg only)
+- Maximum argument length (requirements string > 200 chars)
+- Special characters in arguments (quotes, slashes, hyphens, parentheses)
+- Partial/corrupt STATE.md (exists but missing required `## Phase:` header)
+- Boundary values (exactly at threshold: `--quick` auto-suggest fires at ≤4 plugins)
+- Resuming from a stage that is already complete
+- Multiple flags combined in unexpected order
+- Empty string value for a required positional argument
+
+### `error` — Error Path Coverage
+
+Known error conditions the command must handle gracefully:
+- Unrecognized VERB or invalid VERB+TYPE combo
+- Required argument missing (e.g., `migrate` with no path)
+- `resume` when no STATE.md exists
+- Filesystem errors (`.planning/` not writeable, file locked)
+- STATE.md records wrong VERB for current invocation
+- Spawned agent fails or times out mid-pipeline
+- User declines at every approval gate — what does the command say next?
+- Command invoked in a non-moku project (no `src/` or `package.json`)
+
+### `adversarial` — Injection and Abuse
+
+Inputs designed to expose missing guards:
+- Shell metacharacters in arguments: `create framework "x; rm -rf ~"`
+- Path traversal: `create ../../../etc/passwd "desc"`
+- Argument that mimics an internal keyword: `create resume "a framework"`
+- Extremely long input (stress test prompt truncation)
+- Second invocation without STATE.md reset (detect and offer resume, not overwrite)
+- Conflicting flags: `--quick` with `resume` verb (which wins?)
+
+---
+
+## Gap Taxonomy
+
+All gaps are classified into exactly one type. Use these names in all agent output contracts.
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `missing-error-handling` | Reachable error condition with no documented recovery path | `migrate` with invalid URL — command doesn't say what to show |
+| `ambiguous-step` | Step has multiple valid interpretations; two reasonable readers would do different things | "If no TYPE found" — token scanning order is unspecified |
+| `contradiction` | Two sections give conflicting instructions | Step 0 strips `--quick` but later step references `$ARGUMENTS` raw |
+| `missing-edge-case` | A real user input is not handled | `create framework` with empty description string |
+| `silent-failure` | Error condition reached but command gives no user-visible output | STATE.md.bak write fails, command continues silently |
+| `inefficiency` | Step does more work than needed or in wrong order | Re-reading a file already loaded in an earlier step |
+| `missing-guard` | Downstream step assumes something upstream steps don't guarantee | Stage 2 assumes plugin table exists but Stage 1 approval doesn't enforce format |
+| `state-corruption-risk` | Write operation can leave state inconsistent if interrupted | Writing STATE.md without backup atomicity |
+| `undocumented-assumption` | Command silently assumes a tool/file/env exists without checking | Assumes `bun` is in PATH without checking |
+| `user-experience-gap` | Command doesn't tell user what to do next after an outcome | After plan-checker BLOCKER, no guidance on what to fix |
+
+---
+
+## Circuit Breaker Thresholds
+
+| Setting | Default | Config key in moku.local.md | Floor |
+|---------|---------|------------------------------|-------|
+| Max scenarios per audit | 20 | `auditMaxScenarios` | 5 |
+| Simulator batch size | 5 | (hardcoded) | — |
+| Max parallel simulators | min(maxParallelAgents, 5) | `maxParallelAgents` | 1 |
+| Max real-execution scenarios | 5 | (hardcoded) | — |
+| Max iterate passes | 3 | `auditIterateLimit` | 1 |
+| Max user edit rounds at gate | 3 | (hardcoded) | — |
+
+**AUDIT-STABLE:** Zero BLOCKERs + ≤2 WARNINGs across all simulated and real-executed scenarios. When stable, the synthesizer sets `"verdict": "PASS"` in its output contract and the command prints:
+
+```
+AUDIT-STABLE: {command}.md passed all {N} scenarios.
+Zero blockers. {M} informational suggestions noted (not applied).
+```
+
+**Trimming priority when over cap:** adversarial → edge → error → valid. Never trim below 2 per category.
+
+---
+
+## Temp Project Bootstrap Templates
+
+Use these exact templates when setting up `AUDIT_TMP` for real execution. The executor adjusts per-scenario preconditions after setup.
+
+### `package.json`
+```json
+{
+  "name": "moku-audit-testbed",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "lint": "echo 'lint ok'",
+    "format": "echo 'format ok'",
+    "test": "echo 'tests ok'"
+  },
+  "dependencies": {
+    "@moku-labs/core": "*"
+  }
+}
+```
+
+### `src/config.ts`
+```typescript
+import { createCoreConfig } from '@moku-labs/core';
+
+export interface Config {
+  name: string;
+}
+
+export interface Events {
+  ready: void;
+}
+
+export const { createPlugin, createCore } = createCoreConfig<Config, Events>('audit-testbed', {
+  config: { name: 'testbed' },
+});
+```
+
+### `src/index.ts`
+```typescript
+import { createCore } from './config.js';
+
+export const { createApp } = createCore({
+  plugins: [],
+});
+```
+
+### `.planning/STATE.md` (neutral starting state)
+```markdown
+## Phase: planning
+## Verb: create
+## Type: framework
+## Target: Audit Testbed
+## Skeleton: not-started
+## Next Action: /moku:build resume
+```
+
+---
+
+## Diff Generation Rules
+
+The synthesizer applies these rules when writing the unified diff and improved command:
+
+1. **Context lines:** Show 3 lines before and after each change (standard unified diff)
+2. **Hunk format:** `@@ -N,M +N,M @@ step-name` — include the step name as hunk context
+3. **Scope:** Fix BLOCKERs (always). Fix WARNINGs (unless `deferred` with justification). Skip INFOs.
+4. **Never change:** Command intent, documented verb list, existing happy-path behavior, argument-hint format
+5. **Always preserve:** `disable-model-invocation: true`, `allowed-tools` list, all `!` bash inline commands
+6. **Add before step:** New guards, validation, and error messages should appear as sub-bullets at the start of the relevant step — not as new steps
+7. **Add after step:** Fallback handling and "what to do next" instructions appear as the last sub-bullet of the relevant step
+
+---
+
+## Executor Precondition Patterns
+
+The executor sets preconditions per scenario before "running" that scenario in `AUDIT_TMP`. Common patterns:
+
+| Precondition | How to set it |
+|---|---|
+| `STATE.md exists at stage N` | Write `.planning/STATE.md` with `## Phase: stage{N}` and `## Next Action:` set appropriately |
+| `STATE.md missing` | Ensure `.planning/STATE.md` does not exist (delete if present) |
+| `STATE.md malformed` | Write `.planning/STATE.md` with only `## Phase:` missing (all other headers present) |
+| `Plugin exists` | Create `src/plugins/{name}/index.ts` with minimal content |
+| `Skeleton committed` | Write STATE.md with `## Skeleton: committed` |
+| `Git checkpoint` | Run `git add -A && git commit -m "checkpoint" --allow-empty` in AUDIT_TMP |
+| `.planning/ not writeable` | `chmod 444 "$AUDIT_TMP/.planning"` before scenario, restore after |
+
+Always restore filesystem state between scenarios: `chmod 755 "$AUDIT_TMP/.planning"` if permissions were changed.


### PR DESCRIPTION
## Summary

- Adds `/moku:audit <command|hooks|all>` — a new command that audits any moku command or the hooks system by generating test scenarios, simulating execution, optionally running in a real temp project, then proposing an improved version (unified diff + full text) for user approval
- Adds 5 specialist agents: `audit-scenario-generator`, `audit-simulator`, `audit-executor`, `audit-synthesizer`, `audit-hooks-analyzer`
- Adds `audit-framework.md` reference with scenario taxonomy, gap taxonomy, temp project templates, and circuit breakers
- Bumps version to 0.13.0

## Key Features

**Command audit mode** (`/moku:audit plan|build|check|status|init`):
- Scenario generator reads every conditional branch and argument pattern
- Simulators run in parallel batches (haiku, pure text), trace each scenario step-by-step
- Executor bootstraps a real temp project, manually applies steps, captures divergences
- Synthesizer deduplicates gaps by agent-agreement count, produces diff + improved command
- User gate: approve/decline/edit before any file is modified
- `--iterate` flag: re-audit after applying fixes, up to 3 passes, stops at AUDIT-STABLE

**Hooks audit mode** (`/moku:audit hooks`):
- Tests every `.sh` script with real inputs via Bash
- Detects root cause of prompt hook false-block (missing output constraints) — documented v0.11.3 partial fix
- Detects missing `skeleton-spec.md` in `approve-planning-writes.sh` allowlist
- Proposes concrete diffs for `hooks.json` and each affected `.sh` file

## Architecture

Mirrors the `validation-coordinator.md` pattern:
```
audit.md
├── moku-audit-scenario-generator (sync, sonnet)
├── Group A: N × moku-audit-simulator (parallel batches, haiku)
├── Group B: 1 × moku-audit-executor (real temp project, sonnet)
├── cross-inject findings (prior findings summary)
└── moku-audit-synthesizer (sync, sonnet) → diff + improved text → user gate
```

## Test plan

- [ ] Run `/moku:audit plan` — verify scenario list is generated, simulators find known edge cases (empty args, missing STATE.md for resume), synthesizer produces readable diff
- [ ] Run `/moku:audit hooks` — verify known issues are detected: prompt hook false-block pattern, skeleton-spec.md allowlist gap
- [ ] Approve a proposal and verify the target command file is edited correctly
- [ ] Run `/moku:audit status --sim-only` — simple command should declare AUDIT-STABLE quickly
- [ ] Run `/moku:audit plan --iterate` — verify it loops and converges

🤖 Generated with [Claude Code](https://claude.com/claude-code)