### PR TITLE
docs: rename createComponent → createIsland across moku skills + agents

### DIFF
--- a/agents/plugin-spec-validator.md
+++ b/agents/plugin-spec-validator.md
@@ -111,7 +111,7 @@ Scan ALL plugins in the framework/project and flag groups that should be merged 
 
 **Detection signals — flag when 2+ plugins share ANY of these:**
 - Same domain prefix in name (e.g. `spaHead`, `spaProgress`, `spaRouter` → "spa")
-- Overlapping event namespaces (e.g. `nav:start`, `nav:end`, `component:mount` all relate to SPA navigation)
+- Overlapping event namespaces (e.g. `nav:start`, `nav:end`, `island:mount` all relate to SPA navigation)
 - Coordinated state (one plugin's events drive another plugin's state changes)
 - Would naturally be configured together by consumers (e.g. SPA navigation settings)
 - Consumer must depend on multiple plugins from the same domain
@@ -136,7 +136,7 @@ The `src/plugins/index.ts` barrel is **required for frameworks** but **optional 
 
 **VIOLATION — helper in barrel:**
 `export { name }` where `name` is NOT a plugin instance (i.e., not a `createPlugin()`
-return value). E.g.: `articleToCard`, `route`, `loadJson`, `boot`, `createComponent`.
+return value). E.g.: `articleToCard`, `route`, `loadJson`, `boot`, `createIsland`.
 
 **VIOLATION — missing structure:**
 - No `// ─── Plugin Instances` or `// ─── Plugin Types` comment headers

--- a/agents/web-validator.md
+++ b/agents/web-validator.md
@@ -26,7 +26,7 @@ Scan all `.tsx` files for CSS class usage:
 
 - **BLOCKER**: `className="..."` with styling classes (not `className` for third-party libs)
 - **BLOCKER**: `class="..."` in JSX
-- **OK**: `data-component="..."`, `data-*` attributes for styling
+- **OK**: `data-island="..."`, `data-*` attributes for styling
 - **OK**: `className` only when interfacing with third-party libraries (must be documented)
 
 **How to check:**
@@ -39,15 +39,15 @@ Scan all `.tsx` files for CSS class usage:
 For each component with a colocated `.css` file:
 
 - **BLOCKER**: CSS file without `@scope` (styles leak globally)
-- **BLOCKER**: `@scope` selector doesn't match `[data-component="..."]` pattern
+- **BLOCKER**: `@scope` selector doesn't match `[data-island="..."]` pattern
 - **WARNING**: Component `.tsx` missing corresponding `.css` file (unstyled component)
 - **WARNING**: `:scope` pseudo-class not used for the root element styles
-- **OK**: `@scope ([data-component="name"]) { ... }`
+- **OK**: `@scope ([data-island="name"]) { ... }`
 
 **How to check:**
 - For each `.tsx` in `src/components/`, find matching `.css`
-- Read each `.css` and verify `@scope` with `data-component` selector
-- Ensure the data-component value matches between `.tsx` and `.css`
+- Read each `.css` and verify `@scope` with `data-island` selector
+- Ensure the data-island value matches between `.tsx` and `.css`
 
 ### 3. @layer Ordering
 
@@ -87,13 +87,13 @@ Check `src/styles/tokens.css` for proper token architecture:
 Validate client-side interactivity patterns:
 
 - **BLOCKER**: Framework-heavy interactivity (React/Preact hooks for DOM manipulation instead of vanilla TS islands)
-- **WARNING**: Island file not using `createComponent` factory pattern
+- **WARNING**: Island file not using `createIsland` factory pattern
 - **WARNING**: Island missing `onDestroy` cleanup (memory leak risk)
-- **OK**: `*Island.ts` files with `createComponent` pattern, proper lifecycle
+- **OK**: `*Island.ts` files with `createIsland` pattern, proper lifecycle
 
 **How to check:**
 - Find all `*Island.ts` files in `src/components/`
-- Verify they use `createComponent` with `onCreate`, `onDestroy`
+- Verify they use `createIsland` with `onCreate`, `onDestroy`
 - Check for `useState`, `useEffect` used for DOM manipulation (should be islands instead)
 
 ### 6. Component Naming Conventions
@@ -172,7 +172,7 @@ Internal links must be built from the route map's `urls` builder (`createUrls`) 
 - Violations: [none / list with file:line]
 
 ### @scope Encapsulation
-| Component | CSS File | @scope | data-component Match | Status |
+| Component | CSS File | @scope | data-island Match | Status |
 |-----------|----------|--------|---------------------|--------|
 | Dashboard | Dashboard.css | YES | YES | PASS |
 | Header | (missing) | — | — | WARN |
@@ -189,7 +189,7 @@ Internal links must be built from the route map's `urls` builder (`createUrls`) 
 - Dark mode (light-dark): [YES / PARTIAL / NO]
 
 ### Island Architecture
-| Island | createComponent | onCreate | onDestroy | Status |
+| Island | createIsland | onCreate | onDestroy | Status |
 |--------|----------------|----------|-----------|--------|
 | ShareButtons | YES | YES | YES | PASS |
 | Navigation | YES | YES | NO | WARN |

--- a/skills/moku-core/SKILL.md
+++ b/skills/moku-core/SKILL.md
@@ -314,8 +314,8 @@ export const routerPlugin = createPlugin('router', {   // export uses <name>Plug
 });
 
 // 3. moku-web: Island handles client-side navigation
-// components/NavigationIsland.ts — vanilla TS, no framework
-export const Navigation = createComponent('nav', {
+// islands/NavigationIsland.ts — vanilla TS, no framework
+export const Navigation = createIsland('nav', {
   onCreate(el) { el.querySelectorAll('a').forEach(a => a.addEventListener('click', handleNav)); },
 });
 ```

--- a/skills/moku-core/references/glossary.md
+++ b/skills/moku-core/references/glossary.md
@@ -27,7 +27,7 @@ Ship pre-expanded in the default `eslint.config.ts`:
 ```
 
 Use a scoped `eslint-disable` only for canonical spec **type names** that are abbreviations
-(e.g. `EnvVarSpec`, `ComponentDef`) — do NOT put PascalCase type names in the allowList.
+(e.g. `EnvVarSpec`, `IslandDef`) — do NOT put PascalCase type names in the allowList.
 
 ## 2. cspell / dictionary `words` (prose in comments, docs, Markdown)
 

--- a/skills/moku-core/references/moku-frameworks.md
+++ b/skills/moku-core/references/moku-frameworks.md
@@ -170,7 +170,7 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
 >   `mermaid-isomorphic@^3.0.0`** (+ playwright/browser).
 > - **`::embed` lazy iframe facades + `lazyEmbed` island (v1.10.0, #70; enhanced v1.11.0, #71).**
 >   `::embed{src="…" title="…" width? height?}` leaf directives rewrite to a static
->   click-to-activate `<figure data-component="lazy-embed">` — NO iframe (or its network/JS cost)
+>   click-to-activate `<figure data-island="lazy-embed">` — NO iframe (or its network/JS cost)
 >   until the reader clicks, when the new **`lazyEmbed`** SPA island swaps in the real
 >   `<iframe loading="lazy">`. `src` may be http(s), root-relative, or a co-located relative path
 >   resolved to the shared `/<slug>/…` URL; `width`×`height` reserve the box aspect-ratio. Provider
@@ -179,7 +179,7 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
 > - **`::gallery` folder galleries (v1.12.0, #72).** `::gallery{src="./images/dir/" caption="…"}`
 >   reads the co-located folder at build, sorts its images, rewrites each to its shared `/<slug>/…`
 >   URL, and renders them through a Preact component (default `GalleryTrack`, or consumer
->   `gallery.component`) into `<div data-component="gallery">`; the swipe/keyboard/lightbox island is
+>   `gallery.component`) into `<div data-island="gallery">`; the swipe/keyboard/lightbox island is
 >   **consumer-provided**. Provider option `gallery?: boolean | { component }`; requires
 >   `trustedContent: true`.
 > - **SPA/build fixes.** v1.8.1 (#64) titleTemplate applied on DATA-path client nav; v1.8.2 (#67/#68)
@@ -189,7 +189,7 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
 >
 > **New public exports (`.`):** runtime `EmbedFacadeButton`, `GalleryTrack`; types
 > `EmbedFacade` / `EmbedFacadeProps` / `EmbedOptions` and `GalleryComponent` / `GalleryOptions` /
-> `GalleryProps` / `GallerySlide`. **`lazyEmbed`** (+ `createComponent`) is exported from **both** `.`
+> `GalleryProps` / `GallerySlide`. **`lazyEmbed`** (+ `createIsland`) is exported from **both** `.`
 > and `./browser` (the island runs client-side); the facade/gallery **components + named types are
 > `.`-only** build-time concerns (also reachable as `Content.*` via the `Content` namespace on
 > `./browser`). **New optional `peerDependency` `mermaid-isomorphic@^3.0.0`** (only when `mermaid` is

--- a/skills/moku-core/references/spec/15-PLUGIN-STRUCTURE.md
+++ b/skills/moku-core/references/spec/15-PLUGIN-STRUCTURE.md
@@ -651,7 +651,7 @@ plugins/
 
 ### 3.5 SPA Plugins
 
-Client routing, component lifecycle, head management, progress indicators, hydration.
+Client routing, island lifecycle, head management, progress indicators, hydration.
 
 **Tier: Standard (single concern) or Very Complex (full SPA engine with multiple modules).**
 
@@ -686,10 +686,10 @@ plugins/
     progress/
       state.ts               # Progress bar state (active flag, element ref).
       api.ts                 # start(), done() — navigation progress bar.
-    components/
-      types.ts               # ComponentDef, ComponentHooks, ComponentInstance.
-      state.ts               # Component registry, mounted instances map.
-      api.ts                 # createComponent(), scanAndMount(), unmountPageSpecific().
+    islands/
+      types.ts               # IslandDef, IslandHooks, IslandInstance.
+      state.ts               # Island registry, mounted instances map.
+      api.ts                 # createIsland(), scanAndMount(), unmountPageSpecific().
     router/
       types.ts               # PageData, RouterHandlers.
       state.ts               # Navigation state (active, cleanup).
@@ -699,7 +699,7 @@ plugins/
       unit/
         head-api.test.ts           # Unit test.
         progress-api.test.ts       # Unit test.
-        components-api.test.ts     # Unit test.
+        islands-api.test.ts     # Unit test.
         router-api.test.ts         # Unit test.
       integration/
         spa.test.ts                # Integration test.
@@ -711,7 +711,7 @@ import { createPlugin } from '../../config';
 import { routerPlugin } from '../router';
 import { createHeadApi } from './head/api';
 import { createProgressState, createProgressApi } from './progress/api';
-import { createComponentsState, createComponentsApi } from './components/api';
+import { createIslandsState, createIslandsApi } from './islands/api';
 import { createSpaRouterState, createSpaRouterApi } from './router/api';
 import type { SpaEvents } from './types';
 
@@ -720,25 +720,25 @@ export const spaPlugin = createPlugin('spa', {
   config: {
     router: { viewTransitions: false, progressBar: true },
     progress: { enabled: true, color: '#0076ff', height: 2 },
-    components: { swapSelector: 'main > section', componentAttribute: 'data-component' },
+    islands: { swapSelector: 'main > section', islandAttribute: 'data-island' },
   },
   createState: () => ({
     router: createSpaRouterState(),
     progress: createProgressState(),
-    components: createComponentsState(),
+    islands: createIslandsState(),
   }),
   events: register => register.map<SpaEvents>({
     'nav:start':          'Navigation started (before fetch)',
     'nav:end':            'Navigation completed (after DOM swap)',
-    'component:create':   'Component instance created',
-    'component:mount':    'Component mounted into DOM',
-    'component:unmount':  'Component unmounted from DOM',
-    'component:destroy':  'Component permanently destroyed',
+    'island:create':   'Island instance created',
+    'island:mount':    'Island mounted into DOM',
+    'island:unmount':  'Island unmounted from DOM',
+    'island:destroy':  'Island permanently destroyed',
   }),
   api: ctx => ({
     head:       createHeadApi(),
     progress:   createProgressApi(ctx),
-    components: createComponentsApi(ctx),
+    islands: createIslandsApi(ctx),
     router:     createSpaRouterApi(ctx),
   }),
   onStart: ctx => {
@@ -754,13 +754,13 @@ export const spaPlugin = createPlugin('spa', {
       }
     },
     'nav:end': () => {
-      // Complete progress bar, scan for new components
+      // Complete progress bar, scan for new islands
     },
   }),
 });
 ```
 
-**Why one plugin, not four:** The head, progress, components, and router modules share navigation events, coordinate during the nav:start → fetch → swap → nav:end flow, and are always used together. Separate plugins would add registration noise (4 array entries) and API surface clutter (4 top-level names on `app`) for modules that have no independent use case. One very complex plugin with namespaced API (`app.spa.head`, `app.spa.router`) is cleaner.
+**Why one plugin, not four:** The head, progress, islands, and router modules share navigation events, coordinate during the nav:start → fetch → swap → nav:end flow, and are always used together. Separate plugins would add registration noise (4 array entries) and API surface clutter (4 top-level names on `app`) for modules that have no independent use case. One very complex plugin with namespaced API (`app.spa.head`, `app.spa.router`) is cleaner.
 
 Store with slices and middleware (complex):
 

--- a/skills/moku-plugin/SKILL.md
+++ b/skills/moku-plugin/SKILL.md
@@ -91,7 +91,7 @@ plugins/
 
 ## Very Complex Plugin Structure
 
-When multiple plugins share a domain (e.g. `spaHead`, `spaProgress`, `spaRouter`, `components` all relate to SPA), merge into one plugin with sub-module directories.
+When multiple plugins share a domain (e.g. `spaHead`, `spaProgress`, `spaRouter`, `islands` all relate to SPA), merge into one plugin with sub-module directories.
 
 ```
 plugins/spa/
@@ -99,7 +99,7 @@ plugins/spa/
   types.ts           # Shared config, state, events, context type.
   head/api.ts
   progress/state.ts, progress/api.ts
-  components/types.ts, components/state.ts, components/api.ts
+  islands/types.ts, islands/state.ts, islands/api.ts
   router/types.ts, router/state.ts, router/api.ts
 ```
 
@@ -329,9 +329,9 @@ export const spaPlugin = createPlugin('spa', {
   }),
 });
 
-// moku-web: Island mounts on data-component, uses SPA plugin API
-// components/NavIsland.ts
-export const Nav = createComponent('nav', {
+// moku-web: Island mounts on data-island, uses SPA plugin API
+// islands/NavIsland.ts
+export const Nav = createIsland('nav', {
   onNavEnd({ doc }) { /* update active link from new doc */ },
 });
 

--- a/skills/moku-plugin/references/domain-scenarios.md
+++ b/skills/moku-plugin/references/domain-scenarios.md
@@ -81,14 +81,14 @@ plugins/spa/
   types.ts           # SpaConfig, SpaState, SpaEvents, SpaCtx
   head/api.ts        # updateHead
   progress/state.ts, progress/api.ts  # start, done
-  components/types.ts, components/state.ts, components/api.ts  # createComponent, scanAndMount
+  islands/types.ts, islands/state.ts, islands/api.ts  # createIsland, scanAndMount
   router/types.ts, router/state.ts, router/api.ts  # createRouter, extractPageData
   __tests__/
 ```
 
-Consumer uses namespaced API: `app.spa.head.updateHead()`, `app.spa.router.createRouter()`, `app.spa.components.createComponent()`.
+Consumer uses namespaced API: `app.spa.head.updateHead()`, `app.spa.router.createRouter()`, `app.spa.islands.createIsland()`.
 
-If a project has separate `spaHead`, `spaProgress`, `spaRouter`, `components` plugins — they should be merged into one `spa` Very Complex plugin.
+If a project has separate `spaHead`, `spaProgress`, `spaRouter`, `islands` plugins — they should be merged into one `spa` Very Complex plugin.
 
 ## SSG Plugins
 Static site generation, content loading, template rendering.

--- a/skills/moku-plugin/references/plugin-patterns.md
+++ b/skills/moku-plugin/references/plugin-patterns.md
@@ -130,7 +130,7 @@ export { spaPlugin } from "./spa";
 
 // ─── Helpers ────────────────────────────────────────────────
 export { route } from "./router";           // builder helper (not the plugin)
-export { createComponent } from "./spa";
+export { createIsland } from "./spa";
 
 // ─── Namespaced Types ───────────────────────────────────────
 export type * as Build from "./build/types";

--- a/skills/moku-plugin/references/plugin-structure.md
+++ b/skills/moku-plugin/references/plugin-structure.md
@@ -129,14 +129,14 @@ plugins/spa/
     api.ts
   progress/
     state.ts, api.ts
-  components/
+  islands/
     types.ts, state.ts, api.ts
   router/
     types.ts, state.ts, api.ts
   README.md
   __tests__/
     unit/
-      components-api.test.ts, router-api.test.ts, ...
+      islands-api.test.ts, router-api.test.ts, ...
     integration/
       spa.test.ts
 ```
@@ -157,7 +157,7 @@ Nested config convention — sub-module configs are just nested objects:
 config: {
   router: { viewTransitions: false, progressBar: true },
   progress: { enabled: true, color: "#0076ff", height: 2 },
-  components: { swapSelector: "main > section", componentAttribute: "data-component" },
+  islands: { swapSelector: "main > section", islandAttribute: "data-island" },
 },
 ```
 
@@ -169,12 +169,12 @@ export type SpaCtx = PluginCtx<SpaConfig, SpaState, SpaEvents>;
 
 Sub-module factory pattern — each module exports a `createXxxApi(ctx)` factory:
 ```typescript
-// components/api.ts
+// islands/api.ts
 import type { SpaCtx } from "../types";
-export function createComponentsApi(ctx: SpaCtx) {
+export function createIslandsApi(ctx: SpaCtx) {
   return {
-    createComponent: (name, hooks) => { /* ... */ },
-    scanAndMount: (root) => scanAndMount(root, ctx.state.components.registered),
+    createIsland: (name, hooks) => { /* ... */ },
+    scanAndMount: (root) => scanAndMount(root, ctx.state.islands.registered),
   };
 }
 ```
@@ -184,7 +184,7 @@ Composed state — root `createState` composes sub-module state factories:
 createState: () => ({
   router: createSpaRouterState(),
   progress: createProgressState(),
-  components: createComponentsState(),
+  islands: createIslandsState(),
 }),
 ```
 
@@ -193,7 +193,7 @@ Event ownership — the plugin declares ALL events; sub-modules emit via `ctx.em
 events: (register) => register.map<SpaEvents>({ /* all sub-module events */ }),
 ```
 
-**When to merge:** If multiple plugins share a domain name (e.g. `spaHead`, `spaProgress`, `spaRouter`, `components` all relate to SPA), coordinate via events, or would naturally be configured together — merge them into one Very Complex plugin.
+**When to merge:** If multiple plugins share a domain name (e.g. `spaHead`, `spaProgress`, `spaRouter`, `islands` all relate to SPA), coordinate via events, or would naturally be configured together — merge them into one Very Complex plugin.
 
 **When to split:** If modules have no shared state, events, or coordination — they should be separate plugins.
 

--- a/skills/moku-web/SKILL.md
+++ b/skills/moku-web/SKILL.md
@@ -34,7 +34,7 @@ the root-config inventory, the data-layer strategies, routing patterns, the hard
 | Framework | `@moku-labs/web` (SSG + SPA over Preact) |
 | Build | Framework `build` plugin (`Bun.build` bundle phase) + `cli` plugin dev loop — no Vite |
 | CSS | Vanilla CSS + @scope + @layer |
-| Interactivity | Island architecture (vanilla TS, `createComponent`) |
+| Interactivity | Island architecture (vanilla TS, `createIsland`) |
 | Package Manager | Bun (pinned deps — `bunfig.toml` `exact = true`) |
 | TypeScript | Strict mode, `jsxImportSource: "preact"`, `types: ["bun","node"]` (TS6) |
 | Tests | Vitest (unit/integration, coverage on `lib/`+`i18n/`) + Playwright (e2e + visual, frozen fixture corpus) |
@@ -129,7 +129,7 @@ custom plugins with `createPlugin("name", spec)` (types infer from the spec; doc
 with a directly-preceding JSDoc block — never destructure exports, see moku-core "Public Export
 Shape"). SEO `<head>` helpers (`meta/og/twitter/jsonLd/canonical/hreflang/feedLink/
 buildArticleHead`), the `route()`/`defineRoutes()` builders, `createUrls(routes, defaultLocale?)`,
-`createComponent` + the built-in `lazyEmbed` island, and the `::embed`/`::gallery` default components
+`createIsland` + the built-in `lazyEmbed` island, and the `::embed`/`::gallery` default components
 `EmbedFacadeButton`/`GalleryTrack` are top-level exports.
 
 **Full catalog — plugins, events, config, the `ctx`/`app` property index, usage:**
@@ -148,7 +148,7 @@ src/
     *.tsx             # Preact components
     *.css             # Per-component CSS (colocated, @scope)
   islands/           # Vanilla TS client-side interactivity
-    index.ts          # Island registry → pluginConfigs.spa.components
+    index.ts          # Island registry → pluginConfigs.spa.islands
     share-buttons.ts, lightbox.ts, ...  # kebab-case, one island per file
   layouts/
     SiteLayout.tsx    # Master page chrome (applied via route .layout())
@@ -180,7 +180,7 @@ classList call anywhere (including examples) is the regression this rule prevent
 
 ```tsx
 // CORRECT
-<div data-component="titlebar">
+<div data-island="titlebar">
   <span data-title>{quote}</span>
 </div>
 
@@ -194,7 +194,7 @@ classList call anywhere (including examples) is the regression this rule prevent
 Each component has a colocated `.css` file using `@scope`:
 
 ```css
-@scope ([data-component="dashboard"]) {
+@scope ([data-island="dashboard"]) {
   :scope {
     display: grid;
     gap: 0.75rem;
@@ -227,19 +227,19 @@ Primitive tokens (raw values) + semantic tokens (purpose-based aliases):
 ```
 
 ### Island Architecture
-Client-side interactivity via vanilla TS, not framework components. `createComponent` comes from
-`@moku-labs/web/browser`; **every lifecycle hook receives a `ComponentContext` `{ el, data }`**
+Client-side interactivity via vanilla TS, not framework components. `createIsland` comes from
+`@moku-labs/web/browser`; **every lifecycle hook receives a `IslandContext` `{ el, data }`**
 (`el` = the bound element, `data` = the page payload from `script#__DATA__`):
 
 ```typescript
-import { createComponent } from '@moku-labs/web/browser';
+import { createIsland } from '@moku-labs/web/browser';
 
-export const shareButtons = createComponent('share', {
+export const shareButtons = createIsland('share', {
   onMount({ el }) { /* attach listeners */ },
   onDestroy({ el }) { /* cleanup */ },
   onNavEnd({ el, data }) { /* update on SPA navigation */ },
 });
-// register via pluginConfigs.spa.components: [shareButtons] (or app.spa.register)
+// register via pluginConfigs.spa.islands: [shareButtons] (or app.spa.register)
 ```
 
 ## Common Mistakes — DON'T Do These
@@ -247,7 +247,7 @@ export const shareButtons = createComponent('share', {
 ```tsx
 // DON'T: Use className — all styling via data-* attributes
 <div className="card active">           // WRONG
-<div data-component="card" data-active> // CORRECT
+<div data-island="card" data-active> // CORRECT
 
 // DON'T: Use React hooks — Preact components are pure, state in islands
 function Counter() {
@@ -257,7 +257,7 @@ function Counter() {
 
 // DON'T: Use classes in CSS selectors
 .card { padding: 1rem; }                 // WRONG
-@scope ([data-component="card"]) {
+@scope ([data-island="card"]) {
   :scope { padding: 1rem; }              // CORRECT — scoped via data attr
 }
 
@@ -267,7 +267,7 @@ article { background: var(--surface-card); }  // CORRECT — semantic token
 
 // DON'T: Write unscoped CSS — component styles must use @scope
 article { padding: 1rem; }              // WRONG — global pollution
-@scope ([data-component="card"]) {
+@scope ([data-island="card"]) {
   article { padding: 1rem; }            // CORRECT — scoped
 }
 ```
@@ -318,18 +318,18 @@ export const rendererPlugin = createPlugin('renderer', {
 // moku-web: Preact component (pure, no hooks)
 export function ArticleCard({ title, summary }: Props) {
   return (
-    <article data-component="article-card">
+    <article data-island="article-card">
       <h2 data-title>{title}</h2>
       <p>{summary}</p>
     </article>
   );
 }
 // Colocated CSS: ArticleCard.css
-// @scope ([data-component="article-card"]) { ... }
+// @scope ([data-island="article-card"]) { ... }
 
 // moku-web: Island for client interactivity
-// article-card.ts — vanilla TS, event-driven; hooks receive ComponentContext { el, data }
-export const articleCard = createComponent('article-card', {
+// article-card.ts — vanilla TS, event-driven; hooks receive IslandContext { el, data }
+export const articleCard = createIsland('article-card', {
   onMount({ el }) { el.querySelector('h2')?.addEventListener('click', expand); },
 });
 ```

--- a/skills/moku-web/references/component-patterns.md
+++ b/skills/moku-web/references/component-patterns.md
@@ -16,7 +16,7 @@ interface Props {
 
 export function TopBar({ quote }: Props) {
   return (
-    <div data-component="titlebar">
+    <div data-island="titlebar">
       <span data-title>{quote}</span>
     </div>
   );
@@ -27,31 +27,31 @@ export function TopBar({ quote }: Props) {
 - **No classes in markup** — all styling via `data-*` attributes
 - **Props interface defined explicitly** — never inline
 - **Pure, functional** — no hooks, no state (state lives in islands)
-- **Semantic data attributes** — `data-component`, `data-variant`, `data-id`, `data-status`
+- **Semantic data attributes** — `data-island`, `data-variant`, `data-id`, `data-status`
 
 ### Naming Convention
 - **Components:** `PascalCase` — `TopBar.tsx`, `DashboardGrid.tsx`
-- **Data attributes:** `kebab-case` — `data-component="split-pane"`
+- **Data attributes:** `kebab-case` — `data-island="split-pane"`
 - **Element attributes:** `data-variant`, `data-id`, `data-status`
 
 ## Vanilla TS Islands (Client-Side Interactivity)
 
 Islands provide client-side behavior. They are NOT framework components — they are imperative,
-event-driven TypeScript, authored with `createComponent(name, hooks)` from
-**`@moku-labs/web/browser`** and registered via `pluginConfigs.spa.components` (or
+event-driven TypeScript, authored with `createIsland(name, hooks)` from
+**`@moku-labs/web/browser`** and registered via `pluginConfigs.spa.islands` (or
 `app.spa.register`). The spa plugin mounts an island on every element whose
-`data-component="<name>"` matches.
+`data-island="<name>"` matches.
 
-**Every lifecycle hook receives a `ComponentContext` `{ el, data }`** — `el` is the bound `Element`,
+**Every lifecycle hook receives a `IslandContext` `{ el, data }`** — `el` is the bound `Element`,
 `data` is the page payload parsed from the inline `script#__DATA__` element. There is no
 bare-element or `{ doc }` hook form.
 
 ```typescript
 // islands/share-buttons.ts
-import { createComponent } from "@moku-labs/web/browser";
+import { createIsland } from "@moku-labs/web/browser";
 
 /** Share-buttons island: wires the copy-link button to the Clipboard API. */
-export const shareButtons = createComponent("share", {
+export const shareButtons = createIsland("share", {
   onMount({ el }) {
     el.querySelector('[data-share="copy"]')?.addEventListener("click", handleCopyClick);
   },
@@ -66,7 +66,7 @@ export const shareButtons = createComponent("share", {
 import { shareButtons } from "./share-buttons";
 import { lightbox } from "./lightbox";
 
-/** All SPA islands registered for hydration — passed to `pluginConfigs.spa.components`. */
+/** All SPA islands registered for hydration — passed to `pluginConfigs.spa.islands`. */
 export const islands = [shareButtons, lightbox];
 ```
 
@@ -77,10 +77,10 @@ added on mount and removed on unmount/destroy.
 - File: `islands/<kebab-case-name>.ts` (e.g. `share-buttons.ts`, `tab-nav.ts`), one island per file,
   re-exported from `islands/index.ts`
 - Export: `camelCase` const (e.g. `shareButtons`)
-- Mount on elements with `data-component="xxx"`
-- Use `createComponent` from **`@moku-labs/web/browser`**
+- Mount on elements with `data-island="xxx"`
+- Use `createIsland` from **`@moku-labs/web/browser`**
 
-### Island Lifecycle Hooks (all receive `ComponentContext { el, data }`)
+### Island Lifecycle Hooks (all receive `IslandContext { el, data }`)
 | Hook | When | Purpose |
 |------|------|---------|
 | `onCreate` | Instance created (before DOM attach) | One-time init |
@@ -103,10 +103,10 @@ Pure Preact markup lives in `components/` with its scoped CSS; client behavior l
 components/
   DashboardGrid.tsx     # Preact component
   DashboardGrid.css     # Scoped CSS (@scope)
-  ShareButtons.tsx      # Preact markup (renders data-component="share")
+  ShareButtons.tsx      # Preact markup (renders data-island="share")
   ShareButtons.css      # Scoped CSS
 islands/
-  share-buttons.ts      # Client-side behavior (createComponent("share", …))
+  share-buttons.ts      # Client-side behavior (createIsland("share", …))
   index.ts              # Island registry
 ```
 
@@ -144,7 +144,7 @@ There is no `.parse()` step — on a client DATA navigation the fetched JSON is 
 
 ## Component taxonomy (organize by role, not by feature)
 
-Group components by role; each renders a `data-component="…"` root (its CSS scope). Names below are
+Group components by role; each renders a `data-island="…"` root (its CSS scope). Names below are
 generic roles — use whatever your project needs:
 
 | role | what it is | scope/notes |
@@ -157,7 +157,7 @@ generic roles — use whatever your project needs:
 
 ## Component ↔ island pairing
 
-A static Preact component renders markup at build; a same-named island (`data-component="name"`)
+A static Preact component renders markup at build; a same-named island (`data-island="name"`)
 adds client behavior. Three general patterns:
 
 - **Plain pairing.** A component renders markup carrying its data (e.g. a copy button with
@@ -166,7 +166,7 @@ adds client behavior. Three general patterns:
 - **Customizing the framework `::gallery` directive.** The Markdown directive
   `::gallery{src="./images/dir/"}` is rendered by YOUR Preact component (wired via
   `content.gallery: { component: MyGallery }`); the framework wraps it in
-  `<div data-component="gallery">`. Pair it with your own gallery island for paging/lightbox — the
+  `<div data-island="gallery">`. Pair it with your own gallery island for paging/lightbox — the
   framework ships only the static markup. (Content-pipeline projects only.)
 - **Customizing the framework `::embed` directive.** `::embed{src title}` renders YOUR facade
   component (wired via `content.embed: { facade: MyFacade }`) — a static click-to-activate

--- a/skills/moku-web/references/css-architecture.md
+++ b/skills/moku-web/references/css-architecture.md
@@ -96,12 +96,12 @@ component = create `Foo.tsx` + `Foo.css`, then add one `@import "../components/F
 
 ## `@scope` for component encapsulation
 
-Each component sheet scopes everything to its `[data-component="…"]` root, so generic element
+Each component sheet scopes everything to its `[data-island="…"]` root, so generic element
 selectors (`article`, `h2`, `time`) never collide across components.
 
 ```css
 /* components/DashboardGrid.css */
-@scope ([data-component="dashboard"]) {
+@scope ([data-island="dashboard"]) {
   :scope { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
 
   article {
@@ -123,14 +123,14 @@ Two refinements the reference uses:
 
 - **Donut scope** — exclude a nested self-scoping child:
   ```css
-  @scope ([data-component="tab-nav"]) to ([data-component="lang-switcher"]) { a { /* tab-nav links, NOT lang-switcher's */ } }
+  @scope ([data-island="tab-nav"]) to ([data-island="lang-switcher"]) { a { /* tab-nav links, NOT lang-switcher's */ } }
   ```
 - **Intentional global atoms** — a reusable leaf that must look identical everywhere is styled
   **without** `@scope` (e.g. `GitTag.css` styles bare `[data-tag]`), so it renders the same inside
   any component's scope. Use sparingly, only for true cross-context atoms.
 
 ### `@scope` rules
-- Selector: `@scope ([data-component="name"])`; `:scope` is the scoped root.
+- Selector: `@scope ([data-island="name"])`; `:scope` is the scoped root.
 - **No classes** — element selectors + `data-*` attributes only (matches the no-`className` markup rule).
 - CSS nesting is allowed inside `@scope`.
 - Always use semantic tokens; never hardcode colors.
@@ -172,7 +172,7 @@ OG-render fonts are a **separate, build-time-only** set in `assets/fonts/og/` (w
 
 ## Conventions
 
-- **Data-attribute styling, never classes** — `[data-component]`, `[data-variant]`, `[data-status]`,
+- **Data-attribute styling, never classes** — `[data-island]`, `[data-variant]`, `[data-status]`,
   runtime state flags like `[data-entered]`/`[data-expanded]` (islands set `el.dataset.x`, never
   `classList`). This rule extends to island code and JSDoc `@example` blocks.
 - **Responsive = scoped media queries** at reference breakpoints (≈900 / 600 / 375 / 320 px); no

--- a/skills/moku-web/references/layout-structure.md
+++ b/skills/moku-web/references/layout-structure.md
@@ -25,7 +25,7 @@ type SiteLayoutProps = {
 
 export function SiteLayout({ locale, activeTab, children }: SiteLayoutProps): VNode {
   return (
-    <main data-component="page-fx">
+    <main data-island="page-fx">
       <header data-sticky>
         <TopBar quote={QUOTES[0] ?? ""} />
         <TabNav locale={locale} activeTab={activeTab} />
@@ -171,7 +171,7 @@ export const app = createApp({
       template: "src/index.html",                   // app-owned shell: <!--moku:lang/head/assets/body-->
       ogImage: { fontDir: "assets/fonts/og", render: OgTemplate, defaultCard: OgDefaultCard, fonts: [/* … */] },
     },
-    spa: { components: islands, viewTransitions: false, progressBar: true },
+    spa: { islands, viewTransitions: false, progressBar: true },
     data: { outputDir: "_data", baseUrl: "/_data/" },
     deploy: { target: "cloudflare-pages", outDir: "dist", productionBranch: "main", ci: true },
     cli: { outDir: "dist", port: Number(process.env.PORT ?? 4173) },
@@ -196,7 +196,7 @@ const app = createApp({
     i18n: i18nConfig,
     router: { routes },
     head: { titleTemplate: `%s — ${SITE.name}` },
-    spa: { components: islands, viewTransitions: false, progressBar: true },
+    spa: { islands, viewTransitions: false, progressBar: true },
     data: { baseUrl: "/_data/" },
   },
 });

--- a/skills/moku-web/references/plugin-index.md
+++ b/skills/moku-web/references/plugin-index.md
@@ -27,14 +27,14 @@ construction) · **No `bin`** — the developer CLI ships as the node-only **`cl
 >     client JS). `mermaid: boolean | { mermaidConfig?, renderDiagrams? }`. Needs the **optional peer
 >     dep `mermaid-isomorphic@^3.0.0`** (+ playwright/browser).
 >   - **`::embed` + `lazyEmbed` island (v1.10.0, enhanced v1.11.0).** `::embed{src title width? height?}`
->     → a click-to-activate `<figure data-component="lazy-embed">` facade; **no iframe** (or its
+>     → a click-to-activate `<figure data-island="lazy-embed">` facade; **no iframe** (or its
 >     network/JS cost) until the reader clicks, when the new **`lazyEmbed`** SPA island swaps in the
 >     real `<iframe loading="lazy">`. `src` = http(s) | root-relative | co-located relative (resolved
 >     to `/<slug>/…`); `width`×`height` reserve the box. `embed: boolean | { facade }` (default
 >     `EmbedFacadeButton`).
 >   - **`::gallery` (v1.12.0).** `::gallery{src="./images/dir/" caption?}` reads the co-located folder
 >     at build, sorts its images, and renders them through a Preact component (default `GalleryTrack`,
->     or `gallery.component`) into `<div data-component="gallery">`. The swipe/keyboard island is
+>     or `gallery.component`) into `<div data-island="gallery">`. The swipe/keyboard island is
 >     **consumer-provided**. `gallery: boolean | { component }`.
 > - **SPA/build fixes (v1.8.1–v1.12.2).** titleTemplate applied on DATA-path client nav (1.8.1);
 >   `llms.txt` synced + font `url()`s kept external in the CSS bundle pass (1.8.2); nav swap always
@@ -173,7 +173,7 @@ Top-level exports (`src/index.ts`):
   defaults) · `contentPlugin` (isomorphic shell, compose explicitly) · `buildPlugin, deployPlugin,
   cliPlugin` (node-only) · `dataPlugin` (optional/isomorphic) · `logPlugin, envPlugin` (core).
 - **Routing DSL:** `defineRoutes`, `route` (builder methods below), `createUrls(routes, defaultLocale?)`.
-- **Islands:** `createComponent(name, hooks)` · `lazyEmbed` (built-in `::embed` activation island — see §2.1).
+- **Islands:** `createIsland(name, hooks)` · `lazyEmbed` (built-in `::embed` activation island — see §2.1).
 - **Content directive components** (`.`-only, build-time SSR'd to static markup; swap via content
   `embed.facade` / `gallery.component`): `EmbedFacadeButton` (default `::embed` facade — a labelled
   `<button>`), `GalleryTrack` (default `::gallery` component — a horizontal slide track). Both also
@@ -191,7 +191,7 @@ Top-level exports (`src/index.ts`):
 **`@moku-labs/web/browser` exports (`src/browser.ts`)** — the ESM-only client entry, node-free by
 construction. Same `createApp`/`createPlugin` over the same isomorphic defaults, PLUS `dataPlugin`,
 `contentPlugin` (the browser-safe SHELL, so route modules can reference it for `ctx.require` in
-build-only loaders), `defineRoutes`, `route`, `createUrls`, `createComponent`, **`lazyEmbed`** (the
+build-only loaders), `defineRoutes`, `route`, `createUrls`, `createIsland`, **`lazyEmbed`** (the
 `::embed` island runs client-side), `browserEnv`, the SEO head primitives, and the type namespaces
 `Content, Data, Env, Head, Log, Router, Spa`. It **excludes** everything node-only:
 `buildPlugin`/`deployPlugin`/`cliPlugin`, `fileSystemContent`, the node providers
@@ -250,7 +250,7 @@ URLs for it, and `/{defaultLocale}/…` is built as a content-identical alias (c
 | `i18nPlugin` | regular · default | Locales + translations w/ default fallback; default locale served at BARE paths (v1.6.0) | — | — | `locales() defaultLocale() isLocale(x) localeName(l) ogLocale(l) t(locale,key)` | `locales, defaultLocale, localeNames?, ogLocaleMap?, translations?` |
 | `routerPlugin` | regular · default | Typed route DSL, RegExp matching, URL gen; routes from config ONLY (no `set()`) | site, i18n | — | `match(pathname) toUrl(name,params) entries() manifest() clientManifest() mode()` | `routes?` — the render mode is GLOBAL `config.mode` (`ssg`\|`spa`\|`hybrid`, default `hybrid`) |
 | `headPlugin` | regular · default | SEO `<head>`: title tmpl, OG, Twitter, canonical, hreflang, JSON-LD; site-level head for bare-path redirects | site, i18n, router | — | `render(resolvedRoute, data) siteHead({url, locale?})` | `titleTemplate?, defaultOgImage?, twitterCard?, twitterHandle?` |
-| `spaPlugin` | regular · default | Client runtime: island hydration + intercepted nav (HTML-over-fetch, or DATA nav when `data` composed); inert on Node | router, head | `spa:navigate`, `spa:navigated`, `spa:component-mount`, `spa:component-unmount` | `register(c) navigate(path) current()` (+ top-level island helpers `createComponent(name,hooks)` and the built-in `lazyEmbed` island for `::embed` facades — register it in `components`) | `swapSelector?` (`"main > section"`), `viewTransitions?` (`false`), `progressBar?` (`true`), `components?` (`[]`) |
+| `spaPlugin` | regular · default | Client runtime: island hydration + intercepted nav (HTML-over-fetch, or DATA nav when `data` composed); inert on Node | router, head | `spa:navigate`, `spa:navigated`, `spa:island-mount`, `spa:island-unmount` | `register(c) navigate(path) current()` (+ top-level island helpers `createIsland(name,hooks)` and the built-in `lazyEmbed` island for `::embed` facades — register it in `islands`) | `swapSelector?` (`"main > section"`), `viewTransitions?` (`false`), `progressBar?` (`true`), `islands?` (`[]`) |
 | `contentPlugin` | regular · explicit (isomorphic SHELL) | Provider-driven Markdown model: sanitized HTML, frontmatter, reading time, locale fallback, per-build memo; drafts hidden only when global `stage === "production"`; build-time directives (`mermaid`/`::embed`/`::gallery`) on the node provider — see §2.1 | i18n | `content:ready`, `content:invalidated` | `loadAll(opts?) load(slug,locale) renderMarkdown(md) invalidate(paths) articleToCard(a) contentDir()` | `providers: ContentProvider[]` — compose `fileSystemContent({ contentDir, defaultAuthor?, trustedContent?, extraRemarkPlugins?, extraRehypePlugins?, shikiTheme?, mermaid?, embed?, gallery? })` (node; `shikiTheme` = `BundledTheme` name OR custom theme object; `mermaid`/`embed`/`gallery` each `boolean \| options` and each REQUIRE `trustedContent: true` — see §2.1) |
 | `buildPlugin` | regular · node-only | SSG orchestrator: pages, feeds, sitemap, OG images (+ default OG card), co-located article images, custom shell/404; **content-hashed bundle filenames + Cloudflare `_headers` cache rules (v1.8.0)**; persists per-page data when `mode!=="ssg"` + `data` composed; incremental dev rebuilds | site, i18n, content, router, head | `build:phase`, `build:complete` | `run(opts?: {outDir?, skipClean?, overrides?, changed?}) phases()` | `outDir, minify, feeds, sitemap, images, ogImage` (`OgImageConfig \| false`; incl. `fontDir, template?, size?, fonts?, render?, defaultCard?`), `injectAssets?` (`true`), `publicDir?` (`"public"`), `notFound?` (`boolean \| { body?, path? }` — asset placeholders substituted, v1.8.0), `localeRedirects?` (`false`), `clientEntry?, template?` (shell w/ `<!--moku:lang/head/assets/body-->` + split `<!--moku:assets:css/js-->` placeholders), `cacheHeaders?` (`boolean \| { assets?, pages? }`, default `true` — emits `outDir/_headers`) |
 | `deployPlugin` | regular · node-only | Deploy `outDir` to Cloudflare Pages (wrangler); scaffolds `wrangler.jsonc` (+ optional GH Actions workflow) | site | `deploy:complete` | `run(opts?) getLastDeployment() init(opts?)` | `target` (`"cloudflare-pages"`), `outDir`, `productionBranch?` (`"main"`), `scrubAllowlist`, `compatibilityDate?, ci?` |
@@ -280,11 +280,11 @@ co-located embed bundles / gallery folders are copied by the existing `content-i
   `content-images` phase copies the bundle to); protocol-relative / `javascript:` / `data:` are rejected.
   `src` + `title` are required; `width`+`height` (positive integer px, both-or-neither) reserve the box
   aspect-ratio so the embed never shifts layout.
-- Renders `<figure class="lazy-embed" data-component="lazy-embed" data-embed-src data-embed-title
+- Renders `<figure class="lazy-embed" data-island="lazy-embed" data-embed-src data-embed-title
   [data-embed-width/height + inline aspect-ratio style]>` wrapping the facade's inner content, SSR'd from a
   Preact component: the built-in **`EmbedFacadeButton`** (a labelled `<button>`) or a consumer
   `facade`. **No iframe is built** — the page costs nothing (no request, no third-party JS) until a click.
-- The built-in **`lazyEmbed` island** (register in `pluginConfigs.spa.components`) listens for a click
+- The built-in **`lazyEmbed` island** (register in `pluginConfigs.spa.islands`) listens for a click
   anywhere on the facade and swaps it for the real `<iframe loading="lazy" allow="fullscreen; autoplay;
   gamepad">`, marking `data-embed-active`. All `.lazy-embed*` chrome is consumer CSS.
 - `EmbedOptions = { facade?: EmbedFacade }` · `EmbedFacade = FunctionComponent<EmbedFacadeProps>` ·
@@ -297,10 +297,10 @@ co-located embed bundles / gallery folders are copied by the existing `content-i
   **folder** read at build: the framework lists it (`.webp/.jpg/.jpeg/.png/.gif/.avif`), sorts
   alphabetically, and rewrites each image to its shared `/<slug>/<dir>/<file>` URL. `src` required; a
   missing/empty folder fails the build. Skipped on the standalone `renderMarkdown()` path (no slug context).
-- Renders `<div class="gallery" data-component="gallery">` wrapping inner content SSR'd from a Preact
+- Renders `<div class="gallery" data-island="gallery">` wrapping inner content SSR'd from a Preact
   component: the built-in **`GalleryTrack`** (a horizontal `<img>` track, usable bare) or a consumer
   `component`. The swipe/keyboard/lightbox island is **consumer-provided** (mount on
-  `[data-component="gallery"]`) — the framework ships only the static track.
+  `[data-island="gallery"]`) — the framework ships only the static track.
 - `GalleryOptions = { component?: GalleryComponent }` · `GalleryComponent = FunctionComponent<GalleryProps>` ·
   `GalleryProps = { slides: readonly GallerySlide[], caption: string, attributes }` ·
   `GallerySlide = { src, alt }` (alt = `"<caption> · N"`, or just `"N"` when no caption).
@@ -327,14 +327,14 @@ registration (by name). Route `.load`/`.generate` contexts carry the same `requi
 | `app.cli.*` | cli | `build(opts?: {assertNotFound?}): Promise<BuildSummary> · serve(opts?: {port?, open?, og?, sitemap?, feeds?}): Promise<void> · preview(opts?: {port?}): Promise<void> · deploy(opts?: {branch?, yes?, guided?}): Promise<DeployOutcome>` |
 | `app.data.*` | data | `write(entries: {path,data}[], opts?: {outDir?}): Promise<{fileCount,bytes,files}> · at(path): Promise<unknown\|null> · urlFor(path): string · fileFor(path): string` |
 
-`island note:` islands are authored with `createComponent(name, hooks)` (lifecycle `onCreate / onMount /
-onNavStart / onNavEnd / onUnMount / onDestroy`; **every hook receives a `ComponentContext` `{ el, data }`**,
-where `data` is the page payload from `script#__DATA__`) and registered via `pluginConfigs.spa.components`
+`island note:` islands are authored with `createIsland(name, hooks)` (lifecycle `onCreate / onMount /
+onNavStart / onNavEnd / onUnMount / onDestroy`; **every hook receives a `IslandContext` `{ el, data }`**,
+where `data` is the page payload from `script#__DATA__`) and registered via `pluginConfigs.spa.islands`
 or `app.spa.register` — see the moku-web skill's Island Architecture section and
-`references/component-patterns.md`. Match elements via `data-component="name"`; islands OUTSIDE the
+`references/component-patterns.md`. Match elements via `data-island="name"`; islands OUTSIDE the
 swap region are persistent across navigations (they get `onNavStart`/`onNavEnd`, never nav-unmounts).
-The framework ships one built-in island, **`lazyEmbed`** (`data-component="lazy-embed"`, for `::embed`
-facades — see §2.1); register it like any other in `pluginConfigs.spa.components`.
+The framework ships one built-in island, **`lazyEmbed`** (`data-island="lazy-embed"`, for `::embed`
+facades — see §2.1); register it like any other in `pluginConfigs.spa.islands`.
 
 ## 4. Event index
 
@@ -346,8 +346,8 @@ facades — see §2.1); register it like any other in `pluginConfigs.spa.compone
 | `build:complete` | `{ outDir: string; pageCount: number; durationMs: number }` | build |
 | `spa:navigate` | `{ from: string; to: string }` | spa |
 | `spa:navigated` | `{ url: string }` | spa |
-| `spa:component-mount` | `{ name: string; el: Element }` | spa |
-| `spa:component-unmount` | `{ name: string; el: Element }` | spa |
+| `spa:island-mount` | `{ name: string; el: Element }` | spa |
+| `spa:island-unmount` | `{ name: string; el: Element }` | spa |
 | `deploy:complete` | `{ url: string; deploymentId: string; branch: string; durationMs: number }` | deploy |
 
 `build` phase names (`PhaseName`, execution order): `bundle, content, images, pages, content-images,
@@ -382,15 +382,15 @@ BUILD (router.mode !== "ssg")              ON DISK                       CLIENT 
 ## 6. Usage snippets
 
 **SSG build (static only):** `import { createApp, contentPlugin, fileSystemContent, buildPlugin } from "@moku-labs/web"` → `createApp({ config: { mode: "ssg" }, plugins: [contentPlugin, buildPlugin], pluginConfigs: { site, i18n, content: { providers: [fileSystemContent({ contentDir })] }, router: { routes }, head, build } })` then `await app.build.run()`.
-**Hybrid (SSG + DATA nav):** add `dataPlugin` for the build (`.` entry); build writes `dist/_data/**` sidecars. The **client entry** is `import { createApp, dataPlugin } from "@moku-labs/web/browser"` → `createApp({ plugins: [dataPlugin], config: { mode: "hybrid" }, pluginConfigs: { site, i18n, router: { routes }, spa: { components: islands } } }).start()` (env auto-wired, node-free).
+**Hybrid (SSG + DATA nav):** add `dataPlugin` for the build (`.` entry); build writes `dist/_data/**` sidecars. The **client entry** is `import { createApp, dataPlugin } from "@moku-labs/web/browser"` → `createApp({ plugins: [dataPlugin], config: { mode: "hybrid" }, pluginConfigs: { site, i18n, router: { routes }, spa: { islands } } }).start()` (env auto-wired, node-free).
 **Dev loop / scripts:** compose `cliPlugin` (+ build/deploy) and write thin per-command scripts — `scripts/build.ts` is just `import { app } from "../src/app"; await app.cli.build();`; likewise `app.cli.serve()` (watch + debounced incremental rebuild + live reload), `app.cli.preview()`, `app.cli.deploy()`.
 **Content directives (`mermaid` · `::embed` · `::gallery`):** enable on the node provider —
 `fileSystemContent({ contentDir: "./content", trustedContent: true, mermaid: true, embed: true, gallery: true })`
 (all three REQUIRE `trustedContent: true`; `mermaid` also needs the optional `mermaid-isomorphic` peer).
 Authors then write ` ```mermaid ` fences, `::embed{src="https://…" title="…" width="400" height="711"}`,
 and `::gallery{src="./images/dir/" caption="…"}`. Register the built-in embed island —
-`import { lazyEmbed } from "@moku-labs/web/browser"` → `pluginConfigs.spa.components: [lazyEmbed]` — and
-supply your own `[data-component="gallery"]` island for swipe/lightbox. Swap the rendered components via
+`import { lazyEmbed } from "@moku-labs/web/browser"` → `pluginConfigs.spa.islands: [lazyEmbed]` — and
+supply your own `[data-island="gallery"]` island for swipe/lightbox. Swap the rendered components via
 `embed: { facade: MyFacade }` / `gallery: { component: MyGallery }` (compose `EmbedFacadeButton` /
 `GalleryTrack` inside a richer one).
 **Custom plugin:** `export const myPlugin = createPlugin("my", { … })` — types infer from the spec; document the export with a directly-preceding JSDoc block (never destructure exports; see moku-core "Public Export Shape").

--- a/skills/moku-web/references/project-spec.md
+++ b/skills/moku-web/references/project-spec.md
@@ -164,9 +164,9 @@ See [layout-structure.md](layout-structure.md) for the full builder contract.
 - **`components/`** — pure Preact `*.tsx` + colocated `*.css` (`@scope`). Group by role: **chrome/nav**
   (header, nav, footer), **views** (list/grid, detail, section blocks), **cards/items**, **interactive
   facades** (forms, media, embeds). All styling via `data-*` attributes — never `className`.
-- **`islands/`** — vanilla-TS client behavior (`createComponent` from `@moku-labs/web/browser`), one
-  kebab file each, re-exported from `islands/index.ts` (→ `pluginConfigs.spa.components`). An island
-  pairs with a component by `data-component="name"`. See [component-patterns.md](component-patterns.md).
+- **`islands/`** — vanilla-TS client behavior (`createIsland` from `@moku-labs/web/browser`), one
+  kebab file each, re-exported from `islands/index.ts` (→ `pluginConfigs.spa.islands`). An island
+  pairs with a component by `data-island="name"`. See [component-patterns.md](component-patterns.md).
 
 ## 8. i18n (optional)
 
@@ -258,7 +258,7 @@ The structure (§2) and rules (§11) are constant; what changes is the data laye
 
 > **Minimal compositions exist.** Not every project needs the full skeleton. An **embeddable widget**
 > or a single-screen tool can skip the router and most dirs: compose `createApp` over the defaults
-> (or just `spa` + your island), mount one `data-component`, and ship one bundled island. Scale up to
+> (or just `spa` + your island), mount one `data-island`, and ship one bundled island. Scale up to
 > the full structure (§2) only as the project grows routes, pages, and data.
 
 ## 14. Scaffold sequence (any project)


### PR DESCRIPTION
Keeps the moku plugin's knowledge (moku-web/plugin/core skills + validator agents + vendored spec §15) in sync with the web/core rename. Preact-component / @layer / src/components refs preserved.