### PR TITLE
chore(sync): sync moku-web skill to @moku-labs/web 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "moku",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "source": "./",
       "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "moku",
   "displayName": "Moku",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
   "author": {
     "name": "Oleksandr Kucherenko",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Moku Claude Code Plugin will be documented in this file.
 
+## 0.53.0 (2026-06-21)
+
+**Synced the `moku-web` skill to `@moku-labs/web@2.0.0`.** The SPA authoring API was renamed
+`createComponent` → `createIsland` (a breaking major): `Component*` types → `Island*`, the
+`data-component` attribute → `data-island`, `spa:component-*` events → `spa:island-*`,
+`ctx.component()` / `app.spa.component()` → `.island()`, and config `spa.components` → `spa.islands`
+(Preact components — `GalleryComponent`, `h(Component)`, the content `gallery.component` option —
+are untouched). Bumped the framework registry `knownVersion` (`1.12.4` → `2.0.0`) so `/moku:upgrade`
+now bumps consumers to web 2.0.0, and added the 1.x → 2.0.0 island-rename codemod to the
+`moku-web-version` migration.
+
 ## 0.52.1 (2026-06-21)
 
 **New `moku-readme` skill — the moku-labs main-README house style.** Captures how the family's repo

--- a/skills/moku-core/references/moku-frameworks.md
+++ b/skills/moku-core/references/moku-frameworks.md
@@ -62,7 +62,7 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
       "localClone": "../web",
       "layer": 2,
       "role": "framework",
-      "knownVersion": "1.12.4",
+      "knownVersion": "2.0.0",
       "skill": "skills/moku-web",
       "pluginIndex": "skills/moku-web/references/plugin-index.md",
       "dependsOn": ["@moku-labs/core"],

--- a/skills/moku-core/references/upgrade-migrations.md
+++ b/skills/moku-core/references/upgrade-migrations.md
@@ -174,6 +174,14 @@ the block below.
      operator the project already uses — `^`/`~`/exact; default to exact if none).
   3. Do NOT add a direct `@moku-labs/core` dependency — `@moku-labs/web` pins core itself.
   4. `bun install` to resolve.
+  5. **Crossing the 1.x → 2.0.0 boundary (BREAKING — SPA "component"→"island" rename):** the
+     SPA authoring API and all SPA-context `component` terminology were renamed to `island`.
+     Apply the codemod across the consumer's `src/` (NOT Preact `components/` — `GalleryComponent`,
+     `h(Component)`, the content `gallery.component` option stay): `createComponent`→`createIsland`;
+     `Component*` SPA type imports → `Island*`; the `data-component` attribute → `data-island`
+     (JSX/CSS/HTML/e2e); `spa:component-mount`/`-unmount` events → `spa:island-*`;
+     `ctx.component()`/`app.spa.component()` → `.island()`; config `spa.components` → `spa.islands`;
+     the `mountIsland` test-harness `components` option → `islands`. No aliases remain (hard rename).
 - **Verify:** `bunx tsc --noEmit` → `bun run lint` → `bun run test`. For a web project also
   `bun run build` (SSG output intact). On failure, route to the **error-diagnostician** agent
   (bounded 3 rounds); breaking API changes between web versions are real source edits — fix

--- a/skills/moku-web/SKILL.md
+++ b/skills/moku-web/SKILL.md
@@ -40,7 +40,7 @@ the root-config inventory, the data-layer strategies, routing patterns, the hard
 | Tests | Vitest (unit/integration, coverage on `lib/`+`i18n/`) + Playwright (e2e + visual, frozen fixture corpus) |
 | Deploy | Cloudflare Pages (`deploy` plugin + `wrangler`); GitHub Actions CI gates deploy |
 
-## Framework API (@moku-labs/web v1.12.4)
+## Framework API (@moku-labs/web v2.0.0)
 
 `@moku-labs/web` is the Layer-2 framework these web patterns sit on. It publishes **two entry
 points**: **`.`** for the Node SSG build (dual ESM+CJS, full surface) and **`@moku-labs/web/browser`**

--- a/skills/moku-web/references/plugin-index.md
+++ b/skills/moku-web/references/plugin-index.md
@@ -7,7 +7,7 @@
 
 # @moku-labs/web — Plugin & Property Index
 
-**Framework:** `@moku-labs/web` · **Synced version:** `1.12.4` · **Layer:** 2 (framework) ·
+**Framework:** `@moku-labs/web` · **Synced version:** `2.0.0` · **Layer:** 2 (framework) ·
 **Depends on:** `@moku-labs/core@0.1.4` (exact pin — consumers must NOT add a direct core dep; now
 lockstep with core's own registry version 0.1.4) + `@moku-labs/common@0.1.1` (**since 1.12.4** — the
 `log`/`env` core plugins are authored in `@moku-labs/common` and re-exported by `web`; public API
@@ -103,7 +103,7 @@ construction) · **No `bin`** — the developer CLI ships as the node-only **`cl
 > v1.9.0–v1.12.0 content directives (`mermaid`/`::embed`/`::gallery`) or `cacheHeaders`/fingerprinted
 > bundle naming. This index is generated from `src/` — **the source is authoritative**.
 
-## 1. Framework API form (v1.12.4)
+## 1. Framework API form (v2.0.0)
 
 `@moku-labs/web` publishes **two entries** (pick by target): **`.`** for the Node SSG build (dual
 ESM+CJS, full surface) and **`@moku-labs/web/browser`** for the client bundle (ESM-only, guaranteed


### PR DESCRIPTION
`moku-sync web` for the just-published **@moku-labs/web@2.0.0**:
- Bump Synced-version + API-form headers (`1.12.4`→`2.0.0`) in the moku-web skill + plugin-index.
- Bump framework registry `knownVersion` `1.12.4`→`2.0.0` → `/moku:upgrade` now bumps consumers to web 2.0.0.
- Add the **1.x→2.0.0 island-rename codemod** (createComponent→createIsland, data-component→data-island, spa:component-*→spa:island-*, ctx/app.spa .component()→.island(), spa.components→spa.islands) to the `moku-web-version` migration.
- Plugin `0.52.1`→`0.53.0`.

Teaching content was already island-accurate (maintained ahead of the stale knownVersion in #7).