### PR TITLE
v0.55.0: enforce Layer-2 src/ root structure post-build

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "moku",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "source": "./",
       "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "moku",
   "displayName": "Moku",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
   "author": {
     "name": "Oleksandr Kucherenko",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Moku Claude Code Plugin will be documented in this file.
 
+## 0.55.0 (2026-06-21)
+
+**Enforce the Layer-2 `src/` root structure rule post-build.** The "root = `config.ts` + `index.ts` + justified entry points only" constraint was previously enforced only at *plan* time, so a framework could drift after planning (e.g. a loose `src/instances.ts` / `src/env-provider.ts` helper, or a non-plugin folder, added during a build). It is now re-checked against the real `src/` filesystem.
+
+### Added
+- **`moku-verifier`** Level 1 (EXISTS) now runs a deterministic `src/` root cleanliness check for frameworks: the root may contain ONLY `config.ts`, `index.ts`, `plugins/`, and entry-point files declared as `package.json` `exports` subpaths. A loose helper file or a non-plugin folder (`src/lib|internal|shared|utils|services|helpers/`) at root is a BLOCKER (`rule: "structure — src/ root"`). Layer-3 consumer apps are exempt.
+- **`moku-spec-validator`** gains check §9 "Framework Structure (src/ root)" — the same rule as a spec-compliance finding, with the cross-plugin-helper fix guidance (co-locate in the owning plugin, or promote it to its own plugin).
+
+### Changed
+- **`plan-stages.md` §Structure Constraints** tightened: explicitly forbids loose helper *files* (not just folders) at `src/` root, names the cross-plugin-shared-helper homes (owning plugin / own plugin / publicly re-exported root module), adds `src/lib|internal|shared/` to the banned-folder list, and requires extra root entry points to be real `package.json` `exports` subpaths. Notes the post-build re-check.
+
 ## 0.54.0 (2026-06-21)
 
 **Synced the vendored Moku Core spec + all family framework knowledge to the `@moku-labs/core@1.5.0`

--- a/agents/spec-validator.md
+++ b/agents/spec-validator.md
@@ -75,6 +75,15 @@ Enforce all Moku Code Rules from agent-preamble.md (R1–R9). Additionally:
 - Helper names must not collide with PluginInstance fields (`name`, `spec`, `_phantom`)
 - Helpers must not access core plugin APIs or any runtime context — they run before `createApp`
 
+### 9. Framework Structure (src/ root — Layer-2 frameworks)
+A Layer-2 framework's `src/` root contains ONLY `config.ts` (Layer 1), `index.ts` (Layer 2), the `plugins/` directory, and entry-point files that are each a declared `package.json` `exports` subpath. The `@moku-labs/web` root (`config.ts`, `index.ts`, `browser.ts`, `testing.ts`, `plugins/`) is the exemplar.
+- A non-entry-point file at `src/` root (a loose helper like `src/instances.ts`, `src/env-provider.ts`) is a **BLOCKER**. Cross-plugin shared helpers belong INSIDE the owning plugin (siblings import `../<owner>/<file>`) or as their own plugin (Nano/Micro, or a core plugin reached via `ctx.require()` for a utility many plugins need); a single-consumer helper co-locates with its consumer. The only sanctioned shared *root* module is one re-exported publicly through `src/index.ts`.
+- A non-plugin folder at root (`src/utils/`, `src/services/`, `src/helpers/`, `src/lib/`, `src/internal/`, `src/shared/`) is a **BLOCKER** — everything non-entry lives under `src/plugins/`.
+- An extra root entry-point file (`src/cli.ts`, `src/browser.ts`) is allowed ONLY when it is an actual `package.json` `exports` subpath; an undeclared one is a **BLOCKER**.
+- **Layer-3 consumer apps are EXEMPT** (no `src/config.ts`; `src/lib/`, `src/main.ts`, etc. are fine — see `consumer-plugins.md`). Apply this check to frameworks only — detect a framework by `src/config.ts` + `src/plugins/` both present.
+
+Cite `spec/01-ARCHITECTURE.md` and the plan-stages §Structure Constraints rule (`rule: "structure — src/ root"`).
+
 ### 10. Core Plugin Compliance
 - Core plugins must be created with `createCorePlugin`, NOT `createPlugin`
 - Core plugin spec must NOT contain `depends`, `events`, or `hooks` — these are forbidden (throws TypeError at runtime)

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -49,6 +49,10 @@ Check that all files required by the plugin's complexity tier are present.
 **Framework-level (frameworks only):**
 - `src/config.ts` exists
 - `src/index.ts` exists
+- **`src/` root is CLEAN** — run `ls src` (Bash) or Glob `src/*`. The root may contain ONLY `config.ts`, `index.ts`, the `plugins/` directory, and additional **entry-point files** that are each declared as a `package.json` `exports` subpath (e.g. `src/browser.ts` → `"./browser"`, `src/testing.ts` → `"./testing"`). To confirm an extra root file is a real entry point, grep `package.json` `exports` for a subpath whose build output matches it; if absent, it is NOT one. Raise a **BLOCKER** (`rule: "structure — src/ root"`, cite `spec/01-ARCHITECTURE.md` + plan-stages §Structure Constraints) for EITHER:
+  - a loose helper file at root (e.g. `src/instances.ts`, `src/env-provider.ts`, `src/utils.ts`) that is not a declared entry point — **Fix:** move a cross-plugin helper INTO its owning plugin (`src/plugins/<owner>/<file>.ts`; siblings import `../<owner>/<file>`) or make it its own plugin; co-locate a single-consumer helper beside its consumer.
+  - a non-plugin folder at root (`src/utils/`, `src/services/`, `src/helpers/`, `src/lib/`, `src/internal/`, `src/shared/`) — **Fix:** everything non-entry lives under `src/plugins/`.
+  The `@moku-labs/web` root (`config.ts`, `index.ts`, `browser.ts`, `testing.ts`, `plugins/`) is the exemplar. This check is **frameworks only** — Layer-3 consumer apps (see the row below) are exempt.
 
 **Consumer app (Layer 3):** no `src/config.ts`; the entry is `src/main.ts`/`src/index.ts` (`createApp`). Custom plugins live in `src/plugins/{name}/` (same per-tier files as above); the `src/plugins/index.ts` barrel is optional. See `${CLAUDE_PLUGIN_ROOT}/skills/moku-core/references/consumer-plugins.md`.
 

--- a/skills/moku-core/references/plan-stages.md
+++ b/skills/moku-core/references/plan-stages.md
@@ -86,10 +86,11 @@ Create `.planning/decisions.md` if it doesn't exist (use template from `plan-tem
 
 #### Structure Constraints
 
-Enforce these constraints on the proposed structure:
-- **Root has config and index files only** — `src/config.ts` and `src/index.ts`
-- **No folders that are NOT plugins** — everything under `src/plugins/`. No `src/utils/`, `src/services/`, `src/helpers/`
-- **CLI/client/server entry point files** are allowed ONLY if absolutely necessary (e.g., `src/cli.ts` for a CLI framework that needs a bin entry). Must be explicitly explained and justified to the user.
+Enforce these constraints on the proposed structure (re-checked post-build by `moku-verifier` + `moku-spec-validator` against the real `src/` filesystem — keep all three in sync). The `@moku-labs/web` root (`config.ts`, `index.ts`, `browser.ts`, `testing.ts`, `plugins/`) is the exemplar:
+- **Root has config and index files only** — `src/config.ts` and `src/index.ts`. This also forbids loose helper FILES at root (`src/instances.ts`, `src/env-provider.ts`, `src/utils.ts`, …), not just folders.
+- **No folders that are NOT plugins** — everything under `src/plugins/`. No `src/utils/`, `src/services/`, `src/helpers/`, `src/lib/`, `src/internal/`, `src/shared/`.
+- **Shared-across-plugins helpers never live as a loose root module.** Co-locate the helper INSIDE the one owning plugin (siblings import it via `../<owner>/<file>`) or make it its own plugin (Nano/Micro, or a core plugin for a utility many plugins need, reached via `ctx.require()`). The ONLY sanctioned shared *root* module is one re-exported publicly through `src/index.ts` (part of the package's public surface).
+- **CLI/client/server entry point files** (`src/cli.ts`, `src/browser.ts`, …) are allowed ONLY if absolutely necessary AND declared as a `package.json` `exports` subpath. Must be explicitly explained and justified to the user.
 
 #### Output: Plugin Tree Diagram + Planned Skeleton
 


### PR DESCRIPTION
## Why

The Layer‑2 "`src/` root = `config.ts` + `index.ts` + justified entry points only" rule was enforced **only at plan time**. Nothing re‑checked the actual `src/` filesystem after a build, so a framework could drift — e.g. `@moku-labs/worker` accumulated loose `src/instances.ts` and `src/env-provider.ts` helpers and a dead `src/cli.ts` shim post‑planning.

This closes the gap: the rule is now re‑checked against the real filesystem during builds and validation.

## Changes

| File | What |
|---|---|
| `agents/verifier.md` | Level 1 (EXISTS) runs a deterministic `ls src` cleanliness check for **frameworks**: root may contain only `config.ts`, `index.ts`, `plugins/`, and files declared as `package.json` `exports` subpaths. Loose helper file or non‑plugin folder (`src/lib\|internal\|shared\|utils\|services\|helpers/`) → **BLOCKER**. Runs every build wave. |
| `agents/spec-validator.md` | New check §9 "Framework Structure (src/ root)" — same rule as a spec finding, with cross‑plugin‑helper fix guidance (co‑locate in owning plugin, or promote to its own plugin). Rides in the `moku-verify` fan‑out. |
| `skills/moku-core/references/plan-stages.md` | §Structure Constraints tightened — forbids loose helper *files* (not just folders), names the sanctioned shared‑helper homes, adds `src/lib\|internal\|shared/` to the ban list, requires extra root entries to be real `exports` subpaths. |
| `.claude-plugin/{plugin,marketplace}.json`, `CHANGELOG.md` | 0.54.0 → **0.55.0**. |

Both validators emit the same `rule: "structure — src/ root"` so the coordinator dedupes. **Layer‑3 consumer apps are explicitly exempt** (`src/lib/`, `src/main.ts` are fine). `@moku-labs/web`'s root is the cited exemplar.

## Validation

- Both manifests valid JSON, in lockstep at 0.55.0.
- Wiring confirmed: `verifier` runs per build wave; `spec-validator` is in the `moku-verify` pipeline — both new checks fire.
