### PR TITLE
v0.56.0: sync moku-worker skill to @moku-labs/worker 0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "moku",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "source": "./",
       "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "moku",
   "displayName": "Moku",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
   "author": {
     "name": "Oleksandr Kucherenko",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Moku Claude Code Plugin will be documented in this file.
 
+## 0.56.0 (2026-06-21)
+
+**Synced `moku-worker` skill knowledge to `@moku-labs/worker@0.11.0`** (`moku-sync`; was 0.9.2). The `0.9.2 → 0.11.0` delta is the `./cli` subpath removal — `deployPlugin`/`cliPlugin` + the deploy manifest types (`ExternalManifest`/`ResourceManifest`) now ship only from the package root — plus docs/branding. No plugin/API/event/config change (still 10 plugins, same set).
+
+### Changed
+- **`skills/moku-worker/SKILL.md` + `references/plugin-index.md`** regenerated for 0.11.0: synced-version stamps bumped, all `@moku-labs/worker/cli` references dropped (entry-points table is now the single `.` entry; the plugin table + dependency graph drop the `./cli` alias).
+- **`moku-frameworks.md`** registry: `worker.knownVersion` `0.9.2 → 0.11.0` + a 0.11.0 provenance note.
+
 ## 0.55.0 (2026-06-21)
 
 **Enforce the Layer-2 `src/` root structure rule post-build.** The "root = `config.ts` + `index.ts` + justified entry points only" constraint was previously enforced only at *plan* time, so a framework could drift after planning (e.g. a loose `src/instances.ts` / `src/env-provider.ts` helper, or a non-plugin folder, added during a build). It is now re-checked against the real `src/` filesystem.

--- a/skills/moku-core/references/moku-frameworks.md
+++ b/skills/moku-core/references/moku-frameworks.md
@@ -84,7 +84,7 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
       "localClone": "../worker",
       "layer": 2,
       "role": "framework",
-      "knownVersion": "0.9.2",
+      "knownVersion": "0.11.0",
       "skill": "skills/moku-worker",
       "pluginIndex": "skills/moku-worker/references/plugin-index.md",
       "dependsOn": ["@moku-labs/core"],
@@ -125,7 +125,15 @@ llms files and the source disagree, **the source wins** (observed at 1.6.1).
 }
 ```
 
-> **Provenance of the `worker` entry:** registered 2026-06-20 (at 0.4.0); **re-synced 2026-06-21** to
+> **Provenance of the `worker` entry (latest sync):** **re-synced 2026-06-21** to `@moku-labs/worker@0.11.0`
+> (npm `dist-tags.latest`). **`0.9.2 → 0.11.0` delta:** `0.10.0` was docs (root-README rewrite) + MIT LICENSE
+> + branded migrate/seed/KV-reset deploy output (no public-surface change); `0.11.0` (#42)
+> `refactor(structure)` cleared `src/` root to `config.ts` + `index.ts` and **removed the `./cli` subpath
+> export** — `deployPlugin`/`cliPlugin` + `ExternalManifest`/`ResourceManifest` now ship **only** from the
+> package root. **No plugin/API/event/config change** (still 10 plugins, same set); the regenerated
+> `plugin-index.md` (synced header `0.11.0`) drops every `./cli` mention.
+>
+> **Provenance of the `worker` entry (0.9.2 history):** registered 2026-06-20 (at 0.4.0); **re-synced 2026-06-21** to
 > `@moku-labs/worker@0.9.2` (npm `dist-tags.latest`; public repo `github.com/moku-labs/worker`). Deps
 > bumped in lockstep with the family: `@moku-labs/core` `0.1.4 → 1.5.0` (exact) + `@moku-labs/common`
 > `0.2.0 → 0.2.1` (shared infra — a skill, not a framework entry); `wrangler` is now an **optional**

--- a/skills/moku-worker/SKILL.md
+++ b/skills/moku-worker/SKILL.md
@@ -9,8 +9,8 @@ description: >
 
 # Moku Worker Patterns
 
-> **Synced to `@moku-labs/worker@0.9.2`** (npm `dist-tags.latest`; surface from the published 0.9.2
-> tarball + the `v0.9.2` git tag source). Full surface — every plugin, its API/config/events, the
+> **Synced to `@moku-labs/worker@0.11.0`** (npm `dist-tags.latest`; surface from the published 0.11.0
+> tarball + the `v0.11.0` git tag source). Full surface — every plugin, its API/config/events, the
 > dependency graph, and the runtime-vs-node-only boundary — is in
 > [`references/plugin-index.md`](references/plugin-index.md). Registered in
 > [`moku-frameworks.md`](../moku-core/references/moku-frameworks.md) (`frameworks[worker]`).
@@ -51,13 +51,12 @@ stays thin), and read env/secrets via `ctx.env` (not raw `process.env` or bare b
 moku-common conventions (MC2/MC3). The one hard rule: this is a **Layer-3 app** — `createApp` only, never
 `createCoreConfig`/`createCore` or a direct `@moku-labs/core` dependency.
 
-## Framework API (@moku-labs/worker v0.9.2)
+## Framework API (@moku-labs/worker v0.11.0)
 
-Two entries: **`@moku-labs/worker`** (runtime — ships in the bundle) and **`@moku-labs/worker/cli`**
-(a back-compat alias for the node-only deploy/CLI; since 0.6.0 `deployPlugin`/`cliPlugin` ship from the
-root too and are tree-shaken out unless you list them — never in the runtime bundle otherwise). `createApp`
-is **synchronous** (built once per isolate, frozen). Bindings are threaded as a **call argument** (`env`),
-never stored.
+One entry: **`@moku-labs/worker`**. The node-only deploy/CLI plugins (`deployPlugin`/`cliPlugin`) ship from
+the same root export and are tree-shaken out unless you list them — never in the runtime bundle otherwise.
+(The `./cli` back-compat subpath was removed in 0.11.0.) `createApp` is **synchronous** (built once per
+isolate, frozen). Bindings are threaded as a **call argument** (`env`), never stored.
 
 ```tsx
 import { createApp, endpoint, kvPlugin } from "@moku-labs/worker";
@@ -82,8 +81,8 @@ export default { fetch: (r, env, ctx) => app.server.handle(r, env, ctx) } satisf
 on the default and `app.<kind>.use("key")` for the rest. Defaults `bindingsPlugin` + `serverPlugin` are
 pre-wired; core `log`/`env`/`stage` are flat-injected on `ctx`. Helpers: `endpoint(path)`,
 `defineDurableObject(name)`. Author consumer plugins with `createPlugin` (generics inferred), typing context
-via `WorkerPluginCtx<Config, State, Events?>`. **Deploy** (root entry, alias `@moku-labs/worker/cli`):
-`deployPlugin` + `cliPlugin` — `deploy.run()`/`cli.deploy()` resolve to a structured `DeployReport`.
+via `WorkerPluginCtx<Config, State, Events?>`. **Deploy** (from the package root): `deployPlugin` +
+`cliPlugin` — `deploy.run()`/`cli.deploy()` resolve to a structured `DeployReport`.
 
 Full catalog (all 10 plugins, every API/config/event, the keyed-map config, the dependency graph, the
 runtime-vs-node-only boundary): **[`references/plugin-index.md`](references/plugin-index.md)**.

--- a/skills/moku-worker/references/plugin-index.md
+++ b/skills/moku-worker/references/plugin-index.md
@@ -1,9 +1,10 @@
 # @moku-labs/worker — Plugin & Property Index
 
-**Synced version:** `0.9.2` (npm `dist-tags.latest`; surface read from the published 0.9.2 tarball +
-the `v0.9.2` git tag's source — upstream `main` HEAD and the `llms-full.txt` catalog body were still
-describing 0.1.0, so the released tarball/tag is the authority. Several prose facts in the catalog were
-stale; this index was regenerated from `src/**` at the tag).
+**Synced version:** `0.11.0` (npm `dist-tags.latest`; surface read from the published 0.11.0 tarball +
+the `v0.11.0` git tag's source. The `0.9.2 → 0.11.0` delta is small: `0.10.0` was docs/LICENSE + branded
+deploy output (no surface change), and `0.11.0` (`#42`) cleared `src/` root to `config.ts` + `index.ts`
+and **removed the `./cli` subpath** — `deployPlugin`/`cliPlugin` + the deploy manifest types now ship
+**only** from the package root. Plugin set, APIs, events, and config are unchanged from 0.9.2).
 Built on `@moku-labs/core@1.5.0`; uses `@moku-labs/common@0.2.1` (supplies the `log` + `env` core
 plugins). `wrangler` is an **optional `peerDependency`** (`>=3`). Engines: node ≥24, bun ≥1.3.14.
 
@@ -23,13 +24,12 @@ requests). Deploy/CLI tooling is built from the same model but tree-shaken out o
 
 | Import | Surface | Bundle |
 |--------|---------|--------|
-| `@moku-labs/worker` (`.`) | Runtime: `createApp`, `createPlugin`, all resource plugin instances, `endpoint`, `defineDurableObject`, `logPlugin`/`envPlugin` (re-exported), **and `deployPlugin`/`cliPlugin`** (node-only graph tree-shaken out unless you list them), types (`WorkerConfig`, `WorkerEvents`, `WorkerEnv`, `WorkerPluginCtx`, `PluginCtx`, `DeployReport`, `SeedConfig`, `ExternalManifest`, `ResourceManifest`, `StageApi` + `Server`/`D1`/`Queues`/`Storage`/`DurableObjects` namespaces). | Runtime plugins ship; deploy/cli pulled in only if listed (`"sideEffects": false`). |
-| `@moku-labs/worker/cli` (`./cli`) | **Back-compat alias** — re-exports `deployPlugin`, `cliPlugin`, `ExternalManifest`, `ResourceManifest`. Kept so existing `import … from "@moku-labs/worker/cli"` call sites keep working; prefer the root import in new code. | Node-only graph; **NEVER** in the Worker bundle. |
+| `@moku-labs/worker` (`.`) | The **only** entry point. Runtime: `createApp`, `createPlugin`, all resource plugin instances, `endpoint`, `defineDurableObject`, `logPlugin`/`envPlugin` (re-exported), **and `deployPlugin`/`cliPlugin`** (node-only graph tree-shaken out unless you list them), types (`WorkerConfig`, `WorkerEvents`, `WorkerEnv`, `WorkerPluginCtx`, `PluginCtx`, `DeployReport`, `SeedConfig`, `ExternalManifest`, `ResourceManifest`, `StageApi` + `Server`/`D1`/`Queues`/`Storage`/`DurableObjects` namespaces). | Runtime plugins ship; deploy/cli pulled in only if listed (`"sideEffects": false`). |
 
-> There is no `@moku-labs/worker/worker` subpath (the spec references one — it does not exist). The real
-> entries are `.` and `./cli`. As of 0.6.0 the node-only `deployPlugin`/`cliPlugin` ship from the **root**
-> too (`./cli` is now just an alias); they only enter a bundle when a consumer actually lists them in
-> `createApp({ plugins })`.
+> There is exactly **one** entry point — `.`. The `./cli` subpath was **removed in 0.11.0** (and the
+> spec-referenced `@moku-labs/worker/worker` subpath never existed). The node-only `deployPlugin`/`cliPlugin`
+> + the manifest types ship from the **root**; they only enter a bundle when a consumer actually lists the
+> plugins in `createApp({ plugins })`.
 
 ## API form
 
@@ -86,12 +86,12 @@ Name strings are bare (`"server"`, `"kv"`); exported instances carry the `Plugin
 | `storage` | `storagePlugin` | Complex | `.` | `get`, `put`, `delete`, `list`, `use(key)`, `deployManifest` (R2 behind a provider seam) |
 | `durableObjects` | `durableObjectsPlugin` | Standard | `.` | `get`, `use`/keyed config, `deployManifest`, `defineDurableObject` |
 | `stage` | `stagePlugin` | Nano (core) | `.` | `isDev`, `isProduction`, `current` — flat-injected `ctx.stage` |
-| `deploy` | `deployPlugin` | Complex | `.` (alias `./cli`) | `run`, `dev`, `seed`, `init`, `checkInfra`, `provisionInfra`, `verifyAuth`, `wrangler` — **node-only** orchestrator |
-| `cli` | `cliPlugin` | Standard | `.` (alias `./cli`) | `dev`, `deploy`, `seed`, `auth`, `doctor`, `whoami`, `wrangler` — **node-only** verbs + branded progress TUI |
+| `deploy` | `deployPlugin` | Complex | `.` | `run`, `dev`, `seed`, `init`, `checkInfra`, `provisionInfra`, `verifyAuth`, `wrangler` — **node-only** orchestrator |
+| `cli` | `cliPlugin` | Standard | `.` | `dev`, `deploy`, `seed`, `auth`, `doctor`, `whoami`, `wrangler` — **node-only** verbs + branded progress TUI |
 
 `log` + `env` core plugins come from `@moku-labs/common` (re-exported `logPlugin`/`envPlugin`). Framework
-defaults: core `log`/`env`/`stage` + `bindings` + `server`. (deploy/cli moved to the root entry in 0.6.0;
-`./cli` is now a back-compat alias.)
+defaults: core `log`/`env`/`stage` + `bindings` + `server`. (deploy/cli ship from the root entry; the
+`./cli` back-compat alias was removed in 0.11.0.)
 
 ## Configuration
 
@@ -137,8 +137,8 @@ through API return values, never `emit`.
 
 ```
 bindings (root) ── server · kv · d1 · queues · storage · durableObjects
-deploy → [storage, kv, d1, queues, durableObjects]   (node-only; root entry, alias ./cli)
-cli    → [deploy]                                      (node-only; root entry, alias ./cli)
+deploy → [storage, kv, d1, queues, durableObjects]   (node-only; root entry)
+cli    → [deploy]                                      (node-only; root entry)
 ```
 
 Each resource plugin exposes `deployManifest()` (an array, one per instance) that `deploy` reads via


### PR DESCRIPTION
## Why

`moku-sync` for the `worker` framework: the `moku-worker` skill was synced to `@moku-labs/worker@0.9.2`, but the package is now at **0.11.0**. The delta is the **`./cli` subpath removal** (this session's `#42`) — `deployPlugin`/`cliPlugin` + the deploy manifest types now ship only from the package root — plus docs/branding (0.10.0). **No plugin / API / event / config change** (still 10 plugins, same set).

## Changes

| File | What |
|---|---|
| `skills/moku-worker/SKILL.md` | Synced banner + API heading → 0.11.0; "Two entries" → "One entry"; dropped the `@moku-labs/worker/cli` alias description. |
| `skills/moku-worker/references/plugin-index.md` | Synced-version → 0.11.0; entry-points table collapsed to the single `.` row (the `./cli` row removed); plugin table + dependency graph drop the `./cli` alias; notes the 0.11.0 removal. |
| `skills/moku-core/references/moku-frameworks.md` | `worker.knownVersion` `0.9.2 → 0.11.0` + a 0.11.0 provenance note (0.9.2 history retained). |
| `.claude-plugin/{plugin,marketplace}.json`, `CHANGELOG.md` | 0.55.0 → **0.56.0**. |

## Validation

- Both manifests + the registry's embedded JSON block parse; `worker.knownVersion = 0.11.0`, all 4 framework entries intact.
- No `./cli` positive references remain in the worker skill (only the "removed in 0.11.0" notices); no `PENDING`/`sync:populate` placeholders.
- The `moku-worker-version` upgrade migration already exists — registry-driven, so only `knownVersion` moved.
