### PR TITLE
feat(validators): flag the createApp entry-point wrapper anti-pattern

### DIFF
--- a/agents/readable-code-validator.md
+++ b/agents/readable-code-validator.md
@@ -30,6 +30,7 @@ A function qualifies as a "wall of text" when its **body** is non-trivial (rough
 5. **Compound boolean inline** in `if`/`while`/`?:` that should be a named predicate. (Rule 6)
 6. **Magic literals** — non-obvious numbers / sentinel strings inline (exempt `0`/`1`/`-1`/`""`). (Rule 7)
 7. **Mixed altitudes / fused concerns** — high-level orchestration interleaved with low-level fiddling in one uninterrupted block. (Rules 8–9)
+8. **Opaque public entry signature** — a public Layer-2 entry export (`createApp` / `createPlugin` in `src/index.ts`) annotated as `typeof <privateBinding>` with an **untyped** arrow param: `export const createApp: typeof boundCreateApp = options => …`. The reader can't see the params or return of the framework's front-door factory — they're hidden behind `typeof` of a private const, and `options` has no visible type at the call site. Flag as **WARNING**, with the fix: a plain binding re-export (`export const createApp = framework.createApp`, whose type is the binding's and fully visible at source) or an explicitly-typed function signature (`export function createApp<…>(options?: CreateAppOptions<…>): App<…>`). This is the readability half only — the type-safety half (body casts to inject config) is the type-validator's BLOCKER under R6/R9 (Check 2.6); do not double-emit a blocker here.
 
 ## What You MUST NOT Flag (exemptions — avoid false positives)
 
@@ -37,6 +38,7 @@ A function qualifies as a "wall of text" when its **body** is non-trivial (rough
 - Pure data / object-literal returns, config objects, type definitions, type-level code.
 - Trivial 1–3 line accessors / delegators.
 - Functions that are mostly JSX / markup.
+- A plain binding re-export of the entry factory — `export const createApp = framework.createApp` / `export const { createApp, createPlugin } = framework`. This is the RECOMMENDED form (its type is the binding's, fully visible at source); never flag it. The opacity flag (#8) targets only the `typeof <private> = options =>` wrapper form.
 - Test files (`**/__tests__/**`, `*.test.ts`) and config files (`*.config.ts`) — EXEMPT.
 
 When uncertain whether a function is genuinely glued vs. acceptably compact, report it as **INFO**, not WARNING. A weak signal is INFO; a clear black box is WARNING. Precision over recall — a false WARNING erodes trust in the whole pipeline.
@@ -50,7 +52,7 @@ When uncertain whether a function is genuinely glued vs. acceptably compact, rep
 ## Process
 
 1. Glob the target scope's source files (`src/**/*.ts`, `src/**/*.tsx`), excluding tests/config.
-2. For each file, read it and locate every function/method whose body is non-trivial.
+2. For each file, read it and locate every function/method whose body is non-trivial. In `src/index.ts`, also check the `createApp` / `createPlugin` entry exports for the opaque `typeof <private> = options =>` form (flag #8).
 3. Apply the "What You Flag" checks; apply the exemptions strictly.
 4. For each genuine offender, record: file, the function name, the body's start/end lines, body line count, the violated rule number(s), and a concrete fix — which stanzas to split (and the intent comment for each), which compound boolean → named predicate, which literal → named constant, which block → extracted helper (balanced; cite Rule 9 if extraction would be over-extraction and a stanza suffices).
 5. Prefer fewer, high-confidence findings over an exhaustive list.

--- a/agents/type-validator.md
+++ b/agents/type-validator.md
@@ -72,6 +72,26 @@ For each hit, apply the **derivable-shape test** — is the shape knowable from 
 
 Cite **R9** and name the concrete replacement type in every finding.
 
+### 2.6 Framework Entry-Point Factory (Layer-2 `createApp` / `createPlugin`)
+
+The Layer-2 entry point (`src/index.ts`) re-exposes the core-bound `createApp` / `createPlugin`. It MUST NOT wrap them in a factory that hides the public signature and injects plugin config through casts. Grep `src/index.ts` (and any file that re-exports `createApp`) for `createApp:\s*typeof`, `boundCreateApp`, and `as typeof`.
+
+**VIOLATION (BLOCKER — R6 + R9):**
+- `export const createApp: typeof <privateBinding> = options => { … }` — a wrapper annotated as `typeof` a private const (`boundCreateApp`, `core.createApp`, …) with an **untyped** arrow param, whose body contains ANY of: `as typeof options`, `… as { … }`, `: Record<string, unknown>`, or other `as` casts that assemble/inject plugin config. This is the canonical R6 (inline assertion) + R9 (`Record<string, unknown>` widened then cast) leak at the framework's front door. It also defeats inference: the consumer-facing signature is invisible (hidden behind `typeof` of a private binding) and the bridged options are cast, not typed.
+
+**Why it happens / the fix:** the wrapper almost always exists to seed CORE-plugin config (env providers, `stage`, `log.mode`) at `createApp` time — but core-plugin config is sealed from `CreateAppOptions.pluginConfigs` by design (spec/05 §1b), so injecting it there forces a cast. Move that default into `createCoreConfig(id, { pluginConfigs: { … } })` (levels 1–2 of the core cascade) instead — exactly how `@moku-labs/web` seeds `log: { mode }`. The entry then collapses to the cast-free plain binding:
+```typescript
+export const createApp = framework.createApp;   // ✅ full inference, zero casts
+export const { createPlugin } = framework;
+```
+If global config genuinely must reach a core plugin per-app (e.g. a `stage` value), make that plugin a **regular** plugin that reads `ctx.global.<field>` — never a `createApp`-time cast bridge.
+
+**ALLOWLISTED (OK):**
+- `export const createApp = framework.createApp` / `export const { createApp, createPlugin } = framework` — plain binding re-export (the web pattern; the type is the binding's, fully inferred).
+- An explicitly-typed wrapper `export function createApp<…>(options?: CreateAppOptions<…>): App<…> { … }` whose body is **cast-free** (no `as`, no `Record<string, unknown>`). Rare — only when a genuinely typed transform is required.
+
+Cite **R6 + R9** and name the fix (move the default to `createCoreConfig`; plain re-export).
+
 ### 3. No Explicit Generics on createPlugin (Preamble R1)
 
 Grep all source files in `src/plugins/` recursively for `createPlugin<` or `createCorePlugin<`. Any angle brackets between the function name and `(` is a BLOCKER. See preamble rule R1.
@@ -149,7 +169,7 @@ For the kernel itself (`@moku-labs/core`):
 
 ## Severity Levels
 
-- **BLOCKER**: `tsc --noEmit` fails; `as any` in plugin code; explicit generics on `createPlugin`; lazy `unknown` / `Record<string, unknown>` annotation for a knowable shape (R9)
+- **BLOCKER**: `tsc --noEmit` fails; `as any` in plugin code; explicit generics on `createPlugin`; lazy `unknown` / `Record<string, unknown>` annotation for a knowable shape (R9); a `createApp` / `createPlugin` entry-point wrapper typed `typeof <private>` with body casts (R6 + R9, Check 2.6)
 - **CRITICAL**: `import` instead of `import type` for type-only usage; inference chain broken (type-level tests missing or failing); missing strict flags
 - **WARNING**: Unnecessary type assertion; could use type narrowing instead of cast; tsconfig missing optional strict flag
 - **INFO**: Type could be narrowed further; consider `satisfies` for better inference
@@ -159,11 +179,12 @@ For the kernel itself (`@moku-labs/core`):
 1. Run `tsc --noEmit` and collect results
 2. Grep for type assertions (`as any`, `as unknown`, `as `) — Check 2
 3. Grep for weak annotations (`Record<string, unknown>`, `: unknown`, `<unknown>`, `: any`) and apply the R9 derivable-shape test — Check 2.5
-4. Grep for `createPlugin<` explicit generics
-5. Check import type compliance
-6. Verify tsconfig strict flags
-7. Read plugin types.ts files for PluginCtx usage
-8. Report findings
+4. Grep `src/index.ts` for `createApp:\s*typeof`, `boundCreateApp`, `as typeof` — the entry-point wrapper anti-pattern (Check 2.6)
+5. Grep for `createPlugin<` explicit generics
+6. Check import type compliance
+7. Verify tsconfig strict flags
+8. Read plugin types.ts files for PluginCtx usage
+9. Report findings
 
 ## Output Format
 
@@ -186,6 +207,11 @@ For the kernel itself (`@moku-labs/core`):
 - Allowlisted (genuine boundary / generic default / test mock): N
 - VIOLATIONS (knowable shape): N
   - [file:line] `Record<string, unknown>` — [derivable type, e.g. "DB row → declare BoardRow"]
+
+### Entry-Point Factory (Check 2.6)
+- `createApp` / `createPlugin` export form: [plain binding / explicitly-typed fn / `typeof`-wrapper — VIOLATION]
+- VIOLATIONS: N
+  - [file:line] `createApp: typeof boundCreateApp = options =>` with body casts — move core-plugin default to `createCoreConfig`; plain re-export `export const createApp = framework.createApp`
 
 ### createPlugin Generics
 - Calls checked: N


### PR DESCRIPTION
Adds a check so the moku type-validator (BLOCKER, Check 2.6 / R6+R9) and readable-code-validator (WARNING, flag #8) catch the `export const createApp: typeof boundCreateApp = options =>` wrapper-with-casts pattern, and steer authors to the plain `createApp = framework.createApp` re-export with core-plugin defaults seeded at `createCoreConfig`.

Source-only docs change (agent prompts); takes effect after the plugin is repackaged/released.