### PR TITLE
v0.57.0: flag the createApp entry-point wrapper anti-pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "moku",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "source": "./",
       "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "moku",
   "displayName": "Moku",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Development toolkit for Moku Core, the micro-kernel TypeScript plugin framework: it scaffolds projects and drives a gated brainstorm \u2192 design \u2192 plan \u2192 build workflow with parallel research, multi-round design exploration, TDD build waves, and a multi-agent validation pipeline. The authoritative Moku Core specification is vendored and injected into every command and agent for spec-grounded decisions.",
   "author": {
     "name": "Oleksandr Kucherenko",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Moku Claude Code Plugin will be documented in this file.
 
+## 0.57.0 (2026-06-21)
+
+**Flag the `createApp` entry-point wrapper anti-pattern.** A Layer-2 framework that wraps the core-bound `createApp` / `createPlugin` in `: typeof <private> = options =>` with body casts (to inject core-plugin config) violates R6 (inline assertions) + R9 (`Record<string, unknown>` widened then cast) at the framework's front door, and hides the public signature behind `typeof` of a private const. Validators now catch it and steer authors to the plain `createApp = framework.createApp` re-export, with core-plugin defaults seeded at `createCoreConfig` (the `@moku-labs/web` pattern).
+
+### Added
+- **`moku-type-validator`** Check 2.6 (BLOCKER, R6+R9): flags an `export const createApp: typeof <private> = options =>` wrapper with body casts; allowlists the plain binding re-export and a cast-free explicitly-typed function.
+- **`moku-readable-code-validator`** flag #8 (WARNING): flags an opaque public entry signature hidden behind `typeof` of a private const; exempts the plain re-export.
+
 ## 0.56.0 (2026-06-21)
 
 **Synced `moku-worker` skill knowledge to `@moku-labs/worker@0.11.0`** (`moku-sync`; was 0.9.2). The `0.9.2 → 0.11.0` delta is the `./cli` subpath removal — `deployPlugin`/`cliPlugin` + the deploy manifest types (`ExternalManifest`/`ResourceManifest`) now ship only from the package root — plus docs/branding. No plugin/API/event/config change (still 10 plugins, same set).


### PR DESCRIPTION
Releases the validator change merged in #11 as **0.57.0** (minor).

Bumps `plugin.json` + `marketplace.json` `0.56.0 → 0.57.0` and adds the CHANGELOG entry.

- **moku-type-validator** Check 2.6 (BLOCKER, R6+R9)
- **moku-readable-code-validator** flag #8 (WARNING)